### PR TITLE
fix: claude_args の allowedTools フォーマットを修正 (#9)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -70,7 +70,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
-          claude_args: "--model claude-opus-4-6 --allowedTools Bash(./gradlew test) Bash(./gradlew check) Bash(./gradlew checkstyleMain) Bash(./gradlew checkstyleTest) Bash(cd frontend && npm run lint) Bash(cd frontend && npm run build)"
+          claude_args: |
+            --model claude-opus-4-6
+            --allowedTools "Bash(./gradlew test),Bash(./gradlew check),Bash(./gradlew checkstyleMain),Bash(./gradlew checkstyleTest),Bash(cd frontend && npm run lint),Bash(cd frontend && npm run build)"
           prompt: |
             # 統合レビュー実施
 


### PR DESCRIPTION
## Summary

- `claude_args` の `--allowedTools` フォーマットを修正
- 1行文字列からYAMLブロックスカラー（`|`）に変更し、`--allowedTools` をカンマ区切り＋ダブルクォート形式に修正
- 修正前: スペース区切りによりツール名がトークン分割されていた（`"Bash"`, `"./gradlew"`, `"test"` ...）
- 修正後: `Bash(./gradlew test)` のように正しくパースされる

## Test plan

- [ ] このPRをマージ後、PR #8 の CI で Claude Code Review が正常動作することを確認
