### PR TITLE
fix: 認証をAPIキーに切り替えしデバッグ出力を有効化 (#9)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -68,8 +68,9 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true
+          show_full_output: true
           claude_args: |
             --model claude-opus-4-6
             --allowedTools "Bash(./gradlew test),Bash(./gradlew check),Bash(./gradlew checkstyleMain),Bash(./gradlew checkstyleTest),Bash(cd frontend && npm run lint),Bash(cd frontend && npm run build)"


### PR DESCRIPTION
## Summary

- 認証方式を `claude_code_oauth_token` から `anthropic_api_key` に切り替え
  - OAuth トークンのフローは OIDC トークン交換を経由するため、直接 API キーよりエラーが起きやすい
- `show_full_output: true` を追加し、失敗時に Claude Code の実際のエラーメッセージが表示されるようにした

## Test plan

- [ ] マージ後、PR #8 の CI で Claude Code Review が正常に動作することを確認
- [ ] 失敗した場合でも `show_full_output: true` により詳細なエラーが確認できること
