### PR TITLE
fix: 認証をOAuthトークンに切り替え（Maxプラン利用）(#9)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -68,7 +68,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           show_full_output: true
           claude_args: |


### PR DESCRIPTION
## Summary

- 認証を `anthropic_api_key`（API従量課金）から `claude_code_oauth_token`（Maxプラン枠利用）に切り替え
- `claude setup-token` で生成した1年間有効なOAuthトークンを使用

## Test plan

- [ ] マージ後、PR #8 の CI で Claude Code Review が正常に動作することを確認
