### PR TITLE
fix: ワークフローの権限とfetch-depthを修正 (#9)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -53,16 +53,17 @@ jobs:
       needs.detect-changes.outputs.backend_changed == 'true' ||
       needs.detect-changes.outputs.frontend_changed == 'true'
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
+      actions: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
## Summary

- ワークフローの permissions を公式サンプルに合わせて修正
  - `contents: read` → `write`（Claude がコードを読み書きするため）
  - `issues: read` → `write`（PR コメント投稿に必要。GitHub では PR コメントは Issues API を使用）
  - `actions: read` を追加（CI 結果の読み取り用）
- `fetch-depth: 1` → `0` に変更（Claude が git の差分・履歴を正しく参照できるように）

## 前回の状況

- CI は pass したがレビュー結果がコメントとして投稿されなかった
- `issues: read` のため コメント投稿の権限がなかった
- `fetch-depth: 1` のため `git diff` や `git log` でエラーが多発していた

## Test plan

- [ ] マージ後、PR #8 で Claude Code Review が正常動作し、レビュー結果が PR コメントに表示されることを確認
