### PR TITLE
fix: track_progressを追加しPRコメント投稿を有効化 (#9)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
+          track_progress: true
           show_full_output: true
           claude_args: |
             --model claude-opus-4-6


### PR DESCRIPTION
## Summary

- `track_progress: true` を追加
- v1 の既知バグ（Issue #567, P1）により、`prompt` モードでレビュー結果が PR コメントに投稿されない問題のワークアラウンド
- `track_progress` を有効にすることで、進捗コメントが PR に投稿され、最終結果もコメント欄に表示される

## Test plan

- [ ] マージ後、PR #8 で Claude Code Review のレビュー結果が PR コメント欄に表示されることを確認
