### PR TITLE
feat: Phase5 申込フォーム実装 (#26)

### DIFF
--- a/backend/src/main/java/com/student/management/config/SecurityConfig.java
+++ b/backend/src/main/java/com/student/management/config/SecurityConfig.java
@@ -81,10 +81,10 @@ public class SecurityConfig {
                                     new ErrorResponse(403, "アクセス権限がありません"));
                         })
                 )
-                .addFilterBefore(applyRateLimitFilter,
-                        UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter,
-                        UsernamePasswordAuthenticationFilter.class);
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(applyRateLimitFilter,
+                        JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/student/management/config/SecurityConfig.java
+++ b/backend/src/main/java/com/student/management/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.student.management.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.student.management.dto.ErrorResponse;
+import com.student.management.security.ApplyRateLimitFilter;
 import com.student.management.security.JwtAuthenticationFilter;
 import com.student.management.security.JwtProperties;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,13 +35,16 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ApplyRateLimitFilter applyRateLimitFilter;
     private final CorsProperties corsProperties;
     private final ObjectMapper objectMapper;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+                          ApplyRateLimitFilter applyRateLimitFilter,
                           CorsProperties corsProperties,
                           ObjectMapper objectMapper) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.applyRateLimitFilter = applyRateLimitFilter;
         this.corsProperties = corsProperties;
         this.objectMapper = objectMapper;
     }
@@ -77,6 +81,8 @@ public class SecurityConfig {
                                     new ErrorResponse(403, "アクセス権限がありません"));
                         })
                 )
+                .addFilterBefore(applyRateLimitFilter,
+                        UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/src/main/java/com/student/management/controller/ApplyController.java
+++ b/backend/src/main/java/com/student/management/controller/ApplyController.java
@@ -1,0 +1,46 @@
+package com.student.management.controller;
+
+import com.student.management.dto.apply.ApplyCourseResponse;
+import com.student.management.dto.apply.ApplyRequest;
+import com.student.management.dto.apply.ApplyResponse;
+import com.student.management.dto.referral.ReferralSourceResponse;
+import com.student.management.service.ApplyService;
+import com.student.management.service.MasterDataService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/apply")
+public class ApplyController {
+
+    private final ApplyService applyService;
+    private final MasterDataService masterDataService;
+
+    public ApplyController(ApplyService applyService, MasterDataService masterDataService) {
+        this.applyService = applyService;
+        this.masterDataService = masterDataService;
+    }
+
+    @GetMapping("/courses")
+    public ResponseEntity<List<ApplyCourseResponse>> listCourses() {
+        return ResponseEntity.ok(applyService.listPublicCourses());
+    }
+
+    @GetMapping("/referral-sources")
+    public ResponseEntity<List<ReferralSourceResponse>> listReferralSources() {
+        return ResponseEntity.ok(masterDataService.getReferralSources());
+    }
+
+    @PostMapping
+    public ResponseEntity<ApplyResponse> apply(@Valid @RequestBody ApplyRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(applyService.submit(request));
+    }
+}

--- a/backend/src/main/java/com/student/management/dto/apply/ApplyCourseResponse.java
+++ b/backend/src/main/java/com/student/management/dto/apply/ApplyCourseResponse.java
@@ -1,0 +1,9 @@
+package com.student.management.dto.apply;
+
+public record ApplyCourseResponse(
+        Long id,
+        String name,
+        String description,
+        Integer price
+) {
+}

--- a/backend/src/main/java/com/student/management/dto/apply/ApplyRequest.java
+++ b/backend/src/main/java/com/student/management/dto/apply/ApplyRequest.java
@@ -1,0 +1,32 @@
+package com.student.management.dto.apply;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ApplyRequest(
+        @NotBlank(message = "氏名は必須です")
+        @Size(max = 100, message = "氏名は100文字以内で入力してください")
+        String name,
+
+        @NotBlank(message = "メールアドレスは必須です")
+        @Email(message = "メールアドレスの形式が不正です")
+        @Size(max = 255, message = "メールアドレスは255文字以内で入力してください")
+        String email,
+
+        @Size(max = 20, message = "電話番号は20文字以内で入力してください")
+        @Pattern(
+                regexp = "^$|^[0-9+()\\-\\s]{8,20}$",
+                message = "電話番号の形式が不正です"
+        )
+        String phone,
+
+        @NotNull(message = "コースは必須です")
+        Long courseId,
+
+        @NotNull(message = "申込経路は必須です")
+        Long referralSourceId
+) {
+}

--- a/backend/src/main/java/com/student/management/dto/apply/ApplyResponse.java
+++ b/backend/src/main/java/com/student/management/dto/apply/ApplyResponse.java
@@ -1,0 +1,13 @@
+package com.student.management.dto.apply;
+
+import java.time.LocalDate;
+
+public record ApplyResponse(
+        Long studentId,
+        Long enrollmentId,
+        Long paymentId,
+        String courseName,
+        Integer amount,
+        LocalDate paymentDueDate
+) {
+}

--- a/backend/src/main/java/com/student/management/dto/apply/ApplyResponse.java
+++ b/backend/src/main/java/com/student/management/dto/apply/ApplyResponse.java
@@ -2,10 +2,10 @@ package com.student.management.dto.apply;
 
 import java.time.LocalDate;
 
+/**
+ * 公開申込 API のレスポンス。内部 ID は返さない（列挙攻撃のリスク回避）。
+ */
 public record ApplyResponse(
-        Long studentId,
-        Long enrollmentId,
-        Long paymentId,
         String courseName,
         Integer amount,
         LocalDate paymentDueDate

--- a/backend/src/main/java/com/student/management/security/ApplyRateLimitFilter.java
+++ b/backend/src/main/java/com/student/management/security/ApplyRateLimitFilter.java
@@ -13,6 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * 公開の {@code POST /api/apply} に対する簡易レート制限（IP 単位・固定ウィンドウ）。
@@ -26,6 +27,7 @@ public class ApplyRateLimitFilter extends OncePerRequestFilter {
 
     private final ObjectMapper objectMapper;
     private final ConcurrentHashMap<String, ConcurrentLinkedQueue<Long>> requestsByIp = new ConcurrentHashMap<>();
+    private final AtomicInteger pruneCounter = new AtomicInteger();
 
     public ApplyRateLimitFilter(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
@@ -40,8 +42,10 @@ public class ApplyRateLimitFilter extends OncePerRequestFilter {
             return;
         }
 
-        String ip = resolveClientIp(request);
         long now = System.currentTimeMillis();
+        maybePruneStaleEntries(now);
+
+        String ip = resolveClientIp(request);
         ConcurrentLinkedQueue<Long> times = requestsByIp.computeIfAbsent(ip, k -> new ConcurrentLinkedQueue<>());
 
         synchronized (times) {
@@ -62,9 +66,42 @@ public class ApplyRateLimitFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    /**
+     * 古い IP エントリを間欠的に掃除（長期間アクセスのない IP のキューが残り続けるのを防ぐ）。
+     */
+    private void maybePruneStaleEntries(long now) {
+        if (pruneCounter.incrementAndGet() % 100 != 0) {
+            return;
+        }
+        requestsByIp.entrySet().removeIf(entry -> {
+            ConcurrentLinkedQueue<Long> q = entry.getValue();
+            synchronized (q) {
+                while (!q.isEmpty() && now - q.peek() > WINDOW_MILLIS) {
+                    q.poll();
+                }
+                return q.isEmpty();
+            }
+        });
+    }
+
     private static boolean isApplyPost(HttpServletRequest request) {
-        return "POST".equalsIgnoreCase(request.getMethod())
-                && PATH.equals(request.getRequestURI());
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            return false;
+        }
+        return PATH.equals(requestPathWithoutContext(request));
+    }
+
+    private static String requestPathWithoutContext(HttpServletRequest request) {
+        String servletPath = request.getServletPath();
+        if (servletPath != null && !servletPath.isEmpty()) {
+            return servletPath;
+        }
+        String uri = request.getRequestURI();
+        String ctx = request.getContextPath();
+        if (ctx != null && !ctx.isEmpty() && uri.startsWith(ctx)) {
+            return uri.substring(ctx.length());
+        }
+        return uri;
     }
 
     private static String resolveClientIp(HttpServletRequest request) {

--- a/backend/src/main/java/com/student/management/security/ApplyRateLimitFilter.java
+++ b/backend/src/main/java/com/student/management/security/ApplyRateLimitFilter.java
@@ -1,0 +1,77 @@
+package com.student.management.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.student.management.dto.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * 公開の {@code POST /api/apply} に対する簡易レート制限（IP 単位・固定ウィンドウ）。
+ */
+@Component
+public class ApplyRateLimitFilter extends OncePerRequestFilter {
+
+    private static final String PATH = "/api/apply";
+    private static final int MAX_REQUESTS_PER_WINDOW = 5;
+    private static final long WINDOW_MILLIS = 60_000L;
+
+    private final ObjectMapper objectMapper;
+    private final ConcurrentHashMap<String, ConcurrentLinkedQueue<Long>> requestsByIp = new ConcurrentHashMap<>();
+
+    public ApplyRateLimitFilter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (!isApplyPost(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String ip = resolveClientIp(request);
+        long now = System.currentTimeMillis();
+        ConcurrentLinkedQueue<Long> times = requestsByIp.computeIfAbsent(ip, k -> new ConcurrentLinkedQueue<>());
+
+        synchronized (times) {
+            while (!times.isEmpty() && now - times.peek() > WINDOW_MILLIS) {
+                times.poll();
+            }
+            if (times.size() >= MAX_REQUESTS_PER_WINDOW) {
+                response.setStatus(429);
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                response.setCharacterEncoding("UTF-8");
+                objectMapper.writeValue(response.getWriter(),
+                        new ErrorResponse(429, "リクエストが多すぎます。しばらくしてから再度お試しください。"));
+                return;
+            }
+            times.add(now);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private static boolean isApplyPost(HttpServletRequest request) {
+        return "POST".equalsIgnoreCase(request.getMethod())
+                && PATH.equals(request.getRequestURI());
+    }
+
+    private static String resolveClientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/backend/src/main/java/com/student/management/service/ApplyService.java
+++ b/backend/src/main/java/com/student/management/service/ApplyService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Locale;
 
 @Service
 @Transactional(readOnly = true)
@@ -57,7 +58,7 @@ public class ApplyService {
 
     @Transactional
     public ApplyResponse submit(ApplyRequest request) {
-        String normalizedEmail = normalize(request.email());
+        String normalizedEmail = normalizeEmail(request.email());
         if (normalizedEmail == null) {
             throw new ApiException(HttpStatus.BAD_REQUEST, "メールアドレスは必須です");
         }
@@ -103,14 +104,7 @@ public class ApplyService {
         payment.setStatus(PAYMENT_UNPAID);
         paymentMapper.insert(payment);
 
-        return new ApplyResponse(
-                student.getId(),
-                enrollment.getId(),
-                payment.getId(),
-                course.getName(),
-                course.getPrice(),
-                dueDate
-        );
+        return new ApplyResponse(course.getName(), course.getPrice(), dueDate);
     }
 
     private ApplyCourseResponse toApplyCourseResponse(CourseWithInstructor course) {
@@ -128,5 +122,16 @@ public class ApplyService {
         }
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    /**
+     * trim のあと小文字化（重複チェック・保存で同一扱いにする）。
+     */
+    private String normalizeEmail(String email) {
+        String trimmed = normalize(email);
+        if (trimmed == null) {
+            return null;
+        }
+        return trimmed.toLowerCase(Locale.ROOT);
     }
 }

--- a/backend/src/main/java/com/student/management/service/ApplyService.java
+++ b/backend/src/main/java/com/student/management/service/ApplyService.java
@@ -33,6 +33,12 @@ public class ApplyService {
     private static final int PAYMENT_DUE_DAYS = 30;
     private static final ZoneId ZONE_TOKYO = ZoneId.of("Asia/Tokyo");
 
+    /**
+     * メール重複時のメッセージ（登録有無の列挙に使われないよう具体理由を伏せる）。
+     */
+    private static final String APPLY_CONFLICT_MESSAGE =
+            "お申し込みを受け付けられませんでした。入力内容をご確認のうえ、時間をおいて再度お試しください。";
+
     private final StudentMapper studentMapper;
     private final EnrollmentMapper enrollmentMapper;
     private final PaymentMapper paymentMapper;
@@ -67,7 +73,7 @@ public class ApplyService {
             throw new ApiException(HttpStatus.BAD_REQUEST, "メールアドレスは必須です");
         }
         if (studentMapper.existsByEmail(normalizedEmail)) {
-            throw new ApiException(HttpStatus.CONFLICT, "同じメールアドレスの受講生が既に存在します");
+            throw new ApiException(HttpStatus.CONFLICT, APPLY_CONFLICT_MESSAGE);
         }
         if (!referralSourceMapper.existsById(request.referralSourceId())) {
             throw new ApiException(HttpStatus.BAD_REQUEST, "申込経路が存在しません");
@@ -92,7 +98,7 @@ public class ApplyService {
         try {
             studentMapper.insert(student);
         } catch (DuplicateKeyException e) {
-            throw new ApiException(HttpStatus.CONFLICT, "同じメールアドレスの受講生が既に存在します");
+            throw new ApiException(HttpStatus.CONFLICT, APPLY_CONFLICT_MESSAGE);
         }
 
         Enrollment enrollment = new Enrollment();

--- a/backend/src/main/java/com/student/management/service/ApplyService.java
+++ b/backend/src/main/java/com/student/management/service/ApplyService.java
@@ -13,6 +13,7 @@ import com.student.management.repository.EnrollmentMapper;
 import com.student.management.repository.PaymentMapper;
 import com.student.management.repository.ReferralSourceMapper;
 import com.student.management.repository.StudentMapper;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,6 +51,9 @@ public class ApplyService {
         this.referralSourceMapper = referralSourceMapper;
     }
 
+    /**
+     * 申込フォーム用のコース一覧。現仕様ではマスタ上すべて公開扱い（非公開フラグは未実装）。
+     */
     public List<ApplyCourseResponse> listPublicCourses() {
         return courseMapper.findAll(null).stream()
                 .map(this::toApplyCourseResponse)
@@ -85,7 +89,11 @@ public class ApplyService {
         student.setChatUsername(null);
         student.setStatus(STATUS_PROVISIONAL);
         student.setReferralSourceId(request.referralSourceId());
-        studentMapper.insert(student);
+        try {
+            studentMapper.insert(student);
+        } catch (DuplicateKeyException e) {
+            throw new ApiException(HttpStatus.CONFLICT, "同じメールアドレスの受講生が既に存在します");
+        }
 
         Enrollment enrollment = new Enrollment();
         enrollment.setStudentId(student.getId());

--- a/backend/src/main/java/com/student/management/service/ApplyService.java
+++ b/backend/src/main/java/com/student/management/service/ApplyService.java
@@ -72,6 +72,7 @@ public class ApplyService {
         if (normalizedEmail == null) {
             throw new ApiException(HttpStatus.BAD_REQUEST, "メールアドレスは必須です");
         }
+        // 先に存在チェック（DB への無駄な INSERT を減らす）。並行申込は UNIQUE + DuplicateKey で 409 に揃える。
         if (studentMapper.existsByEmail(normalizedEmail)) {
             throw new ApiException(HttpStatus.CONFLICT, APPLY_CONFLICT_MESSAGE);
         }

--- a/backend/src/main/java/com/student/management/service/ApplyService.java
+++ b/backend/src/main/java/com/student/management/service/ApplyService.java
@@ -1,0 +1,132 @@
+package com.student.management.service;
+
+import com.student.management.dto.apply.ApplyCourseResponse;
+import com.student.management.dto.apply.ApplyRequest;
+import com.student.management.dto.apply.ApplyResponse;
+import com.student.management.entity.CourseWithInstructor;
+import com.student.management.entity.Enrollment;
+import com.student.management.entity.Payment;
+import com.student.management.entity.Student;
+import com.student.management.exception.ApiException;
+import com.student.management.repository.CourseMapper;
+import com.student.management.repository.EnrollmentMapper;
+import com.student.management.repository.PaymentMapper;
+import com.student.management.repository.ReferralSourceMapper;
+import com.student.management.repository.StudentMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class ApplyService {
+
+    private static final String STATUS_PROVISIONAL = "PROVISIONAL";
+    private static final String ENROLLMENT_ENROLLED = "ENROLLED";
+    private static final String PAYMENT_UNPAID = "UNPAID";
+    private static final int PAYMENT_DUE_DAYS = 30;
+    private static final ZoneId ZONE_TOKYO = ZoneId.of("Asia/Tokyo");
+
+    private final StudentMapper studentMapper;
+    private final EnrollmentMapper enrollmentMapper;
+    private final PaymentMapper paymentMapper;
+    private final CourseMapper courseMapper;
+    private final ReferralSourceMapper referralSourceMapper;
+
+    public ApplyService(StudentMapper studentMapper,
+                        EnrollmentMapper enrollmentMapper,
+                        PaymentMapper paymentMapper,
+                        CourseMapper courseMapper,
+                        ReferralSourceMapper referralSourceMapper) {
+        this.studentMapper = studentMapper;
+        this.enrollmentMapper = enrollmentMapper;
+        this.paymentMapper = paymentMapper;
+        this.courseMapper = courseMapper;
+        this.referralSourceMapper = referralSourceMapper;
+    }
+
+    public List<ApplyCourseResponse> listPublicCourses() {
+        return courseMapper.findAll(null).stream()
+                .map(this::toApplyCourseResponse)
+                .toList();
+    }
+
+    @Transactional
+    public ApplyResponse submit(ApplyRequest request) {
+        String normalizedEmail = normalize(request.email());
+        if (normalizedEmail == null) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "メールアドレスは必須です");
+        }
+        if (studentMapper.existsByEmail(normalizedEmail)) {
+            throw new ApiException(HttpStatus.CONFLICT, "同じメールアドレスの受講生が既に存在します");
+        }
+        if (!referralSourceMapper.existsById(request.referralSourceId())) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "申込経路が存在しません");
+        }
+
+        CourseWithInstructor course = courseMapper.findById(request.courseId())
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "コースが見つかりません"));
+
+        LocalDate today = LocalDate.now(ZONE_TOKYO);
+        LocalDate dueDate = today.plusDays(PAYMENT_DUE_DAYS);
+
+        Student student = new Student();
+        student.setName(request.name().trim());
+        student.setEmail(normalizedEmail);
+        student.setPhone(normalize(request.phone()));
+        student.setAddress(null);
+        student.setBirthdate(null);
+        student.setGender(null);
+        student.setChatUsername(null);
+        student.setStatus(STATUS_PROVISIONAL);
+        student.setReferralSourceId(request.referralSourceId());
+        studentMapper.insert(student);
+
+        Enrollment enrollment = new Enrollment();
+        enrollment.setStudentId(student.getId());
+        enrollment.setCourseId(course.getId());
+        enrollment.setStartDate(today);
+        enrollment.setEndDate(null);
+        enrollment.setStatus(ENROLLMENT_ENROLLED);
+        enrollmentMapper.insert(enrollment);
+
+        Payment payment = new Payment();
+        payment.setStudentId(student.getId());
+        payment.setEnrollmentId(enrollment.getId());
+        payment.setAmount(course.getPrice());
+        payment.setDueDate(dueDate);
+        payment.setPaidDate(null);
+        payment.setStatus(PAYMENT_UNPAID);
+        paymentMapper.insert(payment);
+
+        return new ApplyResponse(
+                student.getId(),
+                enrollment.getId(),
+                payment.getId(),
+                course.getName(),
+                course.getPrice(),
+                dueDate
+        );
+    }
+
+    private ApplyCourseResponse toApplyCourseResponse(CourseWithInstructor course) {
+        return new ApplyCourseResponse(
+                course.getId(),
+                course.getName(),
+                course.getDescription(),
+                course.getPrice()
+        );
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/backend/src/test/java/com/student/management/service/ApplyServiceTest.java
+++ b/backend/src/test/java/com/student/management/service/ApplyServiceTest.java
@@ -19,12 +19,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -61,21 +64,21 @@ class ApplyServiceTest {
         course.setPrice(50000);
         when(courseMapper.findById(10L)).thenReturn(Optional.of(course));
 
-        when(studentMapper.insert(any(Student.class))).thenAnswer(inv -> {
+        doAnswer(inv -> {
             Student s = inv.getArgument(0);
             s.setId(100L);
             return null;
-        });
-        when(enrollmentMapper.insert(any(Enrollment.class))).thenAnswer(inv -> {
+        }).when(studentMapper).insert(any(Student.class));
+        doAnswer(inv -> {
             Enrollment e = inv.getArgument(0);
             e.setId(200L);
             return null;
-        });
-        when(paymentMapper.insert(any(Payment.class))).thenAnswer(inv -> {
+        }).when(enrollmentMapper).insert(any(Enrollment.class));
+        doAnswer(inv -> {
             Payment p = inv.getArgument(0);
             p.setId(300L);
             return null;
-        });
+        }).when(paymentMapper).insert(any(Payment.class));
 
         ApplyRequest request = new ApplyRequest(
                 "山田太郎",
@@ -87,14 +90,14 @@ class ApplyServiceTest {
 
         var response = applyService.submit(request);
 
-        assertThat(response.studentId()).isEqualTo(100L);
-        assertThat(response.enrollmentId()).isEqualTo(200L);
-        assertThat(response.paymentId()).isEqualTo(300L);
         assertThat(response.courseName()).isEqualTo("Java入門");
         assertThat(response.amount()).isEqualTo(50000);
+        assertThat(response.paymentDueDate()).isEqualTo(
+                LocalDate.now(ZoneId.of("Asia/Tokyo")).plusDays(30));
 
         ArgumentCaptor<Student> studentCap = ArgumentCaptor.forClass(Student.class);
         verify(studentMapper).insert(studentCap.capture());
+        assertThat(studentCap.getValue().getEmail()).isEqualTo("a@example.com");
         assertThat(studentCap.getValue().getStatus()).isEqualTo("PROVISIONAL");
         assertThat(studentCap.getValue().getReferralSourceId()).isEqualTo(1L);
 
@@ -108,6 +111,47 @@ class ApplyServiceTest {
         verify(paymentMapper).insert(payCap.capture());
         assertThat(payCap.getValue().getAmount()).isEqualTo(50000);
         assertThat(payCap.getValue().getStatus()).isEqualTo("UNPAID");
+    }
+
+    @Test
+    void submit_normalizesEmailToLowerCase_forDuplicateCheckAndStorage() {
+        when(studentMapper.existsByEmail("user@example.com")).thenReturn(false);
+        when(referralSourceMapper.existsById(1L)).thenReturn(true);
+
+        CourseWithInstructor course = new CourseWithInstructor();
+        course.setId(10L);
+        course.setName("A");
+        course.setPrice(1000);
+        when(courseMapper.findById(10L)).thenReturn(Optional.of(course));
+
+        doAnswer(inv -> {
+            Student s = inv.getArgument(0);
+            s.setId(1L);
+            return null;
+        }).when(studentMapper).insert(any(Student.class));
+        doAnswer(inv -> {
+            Enrollment e = inv.getArgument(0);
+            e.setId(2L);
+            return null;
+        }).when(enrollmentMapper).insert(any(Enrollment.class));
+        doAnswer(inv -> {
+            Payment p = inv.getArgument(0);
+            p.setId(3L);
+            return null;
+        }).when(paymentMapper).insert(any(Payment.class));
+
+        applyService.submit(new ApplyRequest(
+                "山田",
+                "USER@EXAMPLE.COM",
+                "",
+                10L,
+                1L
+        ));
+
+        verify(studentMapper).existsByEmail("user@example.com");
+        ArgumentCaptor<Student> cap = ArgumentCaptor.forClass(Student.class);
+        verify(studentMapper).insert(cap.capture());
+        assertThat(cap.getValue().getEmail()).isEqualTo("user@example.com");
     }
 
     @Test

--- a/backend/src/test/java/com/student/management/service/ApplyServiceTest.java
+++ b/backend/src/test/java/com/student/management/service/ApplyServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDate;
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -152,6 +154,26 @@ class ApplyServiceTest {
         ArgumentCaptor<Student> cap = ArgumentCaptor.forClass(Student.class);
         verify(studentMapper).insert(cap.capture());
         assertThat(cap.getValue().getEmail()).isEqualTo("user@example.com");
+    }
+
+    @Test
+    void submit_whenInsertDuplicateKey_mapsToConflict() {
+        when(studentMapper.existsByEmail("a@example.com")).thenReturn(false);
+        when(referralSourceMapper.existsById(1L)).thenReturn(true);
+        CourseWithInstructor course = new CourseWithInstructor();
+        course.setId(10L);
+        course.setName("Java");
+        course.setPrice(1000);
+        when(courseMapper.findById(10L)).thenReturn(Optional.of(course));
+        doThrow(new DuplicateKeyException("duplicate", null)).when(studentMapper).insert(any(Student.class));
+
+        assertThatThrownBy(() -> applyService.submit(new ApplyRequest(
+                "山田", "a@example.com", "", 10L, 1L)))
+                .isInstanceOf(ApiException.class)
+                .extracting(ex -> ((ApiException) ex).getStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+
+        verify(enrollmentMapper, never()).insert(any());
     }
 
     @Test

--- a/backend/src/test/java/com/student/management/service/ApplyServiceTest.java
+++ b/backend/src/test/java/com/student/management/service/ApplyServiceTest.java
@@ -1,0 +1,192 @@
+package com.student.management.service;
+
+import com.student.management.dto.apply.ApplyRequest;
+import com.student.management.entity.CourseWithInstructor;
+import com.student.management.entity.Enrollment;
+import com.student.management.entity.Payment;
+import com.student.management.entity.Student;
+import com.student.management.exception.ApiException;
+import com.student.management.repository.CourseMapper;
+import com.student.management.repository.EnrollmentMapper;
+import com.student.management.repository.PaymentMapper;
+import com.student.management.repository.ReferralSourceMapper;
+import com.student.management.repository.StudentMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApplyServiceTest {
+
+    @Mock
+    private StudentMapper studentMapper;
+
+    @Mock
+    private EnrollmentMapper enrollmentMapper;
+
+    @Mock
+    private PaymentMapper paymentMapper;
+
+    @Mock
+    private CourseMapper courseMapper;
+
+    @Mock
+    private ReferralSourceMapper referralSourceMapper;
+
+    @InjectMocks
+    private ApplyService applyService;
+
+    @Test
+    void submit_createsStudentEnrollmentAndPayment() {
+        when(studentMapper.existsByEmail("a@example.com")).thenReturn(false);
+        when(referralSourceMapper.existsById(1L)).thenReturn(true);
+
+        CourseWithInstructor course = new CourseWithInstructor();
+        course.setId(10L);
+        course.setName("Java入門");
+        course.setPrice(50000);
+        when(courseMapper.findById(10L)).thenReturn(Optional.of(course));
+
+        when(studentMapper.insert(any(Student.class))).thenAnswer(inv -> {
+            Student s = inv.getArgument(0);
+            s.setId(100L);
+            return null;
+        });
+        when(enrollmentMapper.insert(any(Enrollment.class))).thenAnswer(inv -> {
+            Enrollment e = inv.getArgument(0);
+            e.setId(200L);
+            return null;
+        });
+        when(paymentMapper.insert(any(Payment.class))).thenAnswer(inv -> {
+            Payment p = inv.getArgument(0);
+            p.setId(300L);
+            return null;
+        });
+
+        ApplyRequest request = new ApplyRequest(
+                "山田太郎",
+                "a@example.com",
+                "09012345678",
+                10L,
+                1L
+        );
+
+        var response = applyService.submit(request);
+
+        assertThat(response.studentId()).isEqualTo(100L);
+        assertThat(response.enrollmentId()).isEqualTo(200L);
+        assertThat(response.paymentId()).isEqualTo(300L);
+        assertThat(response.courseName()).isEqualTo("Java入門");
+        assertThat(response.amount()).isEqualTo(50000);
+
+        ArgumentCaptor<Student> studentCap = ArgumentCaptor.forClass(Student.class);
+        verify(studentMapper).insert(studentCap.capture());
+        assertThat(studentCap.getValue().getStatus()).isEqualTo("PROVISIONAL");
+        assertThat(studentCap.getValue().getReferralSourceId()).isEqualTo(1L);
+
+        ArgumentCaptor<Enrollment> enCap = ArgumentCaptor.forClass(Enrollment.class);
+        verify(enrollmentMapper).insert(enCap.capture());
+        assertThat(enCap.getValue().getStudentId()).isEqualTo(100L);
+        assertThat(enCap.getValue().getCourseId()).isEqualTo(10L);
+        assertThat(enCap.getValue().getStatus()).isEqualTo("ENROLLED");
+
+        ArgumentCaptor<Payment> payCap = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentMapper).insert(payCap.capture());
+        assertThat(payCap.getValue().getAmount()).isEqualTo(50000);
+        assertThat(payCap.getValue().getStatus()).isEqualTo("UNPAID");
+    }
+
+    @Test
+    void submit_whenEmailExists_throwsConflict() {
+        when(studentMapper.existsByEmail("dup@example.com")).thenReturn(true);
+
+        ApplyRequest request = new ApplyRequest(
+                "山田",
+                "dup@example.com",
+                "",
+                1L,
+                1L
+        );
+
+        assertThatThrownBy(() -> applyService.submit(request))
+                .isInstanceOf(ApiException.class)
+                .extracting(ex -> ((ApiException) ex).getStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+
+        verify(studentMapper, never()).insert(any());
+    }
+
+    @Test
+    void submit_whenReferralInvalid_throwsBadRequest() {
+        when(studentMapper.existsByEmail("a@example.com")).thenReturn(false);
+        when(referralSourceMapper.existsById(99L)).thenReturn(false);
+
+        ApplyRequest request = new ApplyRequest(
+                "山田",
+                "a@example.com",
+                "",
+                1L,
+                99L
+        );
+
+        assertThatThrownBy(() -> applyService.submit(request))
+                .isInstanceOf(ApiException.class)
+                .extracting(ex -> ((ApiException) ex).getStatus())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+
+        verify(studentMapper, never()).insert(any());
+    }
+
+    @Test
+    void submit_whenCourseMissing_throwsNotFound() {
+        when(studentMapper.existsByEmail("a@example.com")).thenReturn(false);
+        when(referralSourceMapper.existsById(1L)).thenReturn(true);
+        when(courseMapper.findById(999L)).thenReturn(Optional.empty());
+
+        ApplyRequest request = new ApplyRequest(
+                "山田",
+                "a@example.com",
+                "",
+                999L,
+                1L
+        );
+
+        assertThatThrownBy(() -> applyService.submit(request))
+                .isInstanceOf(ApiException.class)
+                .extracting(ex -> ((ApiException) ex).getStatus())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+
+        verify(studentMapper, never()).insert(any());
+    }
+
+    @Test
+    void listPublicCourses_mapsFromCourseMapper() {
+        CourseWithInstructor c = new CourseWithInstructor();
+        c.setId(1L);
+        c.setName("A");
+        c.setDescription("desc");
+        c.setPrice(1000);
+        when(courseMapper.findAll(null)).thenReturn(List.of(c));
+
+        var list = applyService.listPublicCourses();
+
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0).id()).isEqualTo(1L);
+        assertThat(list.get(0).name()).isEqualTo("A");
+        assertThat(list.get(0).price()).isEqualTo(1000);
+    }
+}

--- a/frontend/src/lib/api/apply.ts
+++ b/frontend/src/lib/api/apply.ts
@@ -1,0 +1,17 @@
+import apiClient from '@/lib/api/client';
+import type { ApplyCourse, ApplyInput, ApplyResult, ReferralSourceOption } from '@/types';
+
+export async function fetchApplyCourses() {
+  const response = await apiClient.get<ApplyCourse[]>('/apply/courses');
+  return response.data;
+}
+
+export async function fetchApplyReferralSources() {
+  const response = await apiClient.get<ReferralSourceOption[]>('/apply/referral-sources');
+  return response.data;
+}
+
+export async function submitApplication(input: ApplyInput) {
+  const response = await apiClient.post<ApplyResult>('/apply', input);
+  return response.data;
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** 日本円の通貨表示 */
+export function formatYen(n: number) {
+  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(n)
+}

--- a/frontend/src/pages/public/ApplyCompletePage.tsx
+++ b/frontend/src/pages/public/ApplyCompletePage.tsx
@@ -1,8 +1,6 @@
-import { Link, useLocation } from 'react-router';
+import { useLocation } from 'react-router';
 import { CheckCircle2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ROUTES } from '@/constants';
 import type { ApplyCompleteState } from '@/types';
 
 function formatYen(n: number) {
@@ -76,10 +74,6 @@ export function ApplyCompletePage() {
                 <li>ヒアリング後、受講開始に向けた準備を進めます</li>
               </ol>
             </div>
-
-            <Button asChild className="w-full" size="lg">
-              <Link to={ROUTES.LOGIN}>運営ログインはこちら</Link>
-            </Button>
           </CardContent>
         </Card>
       </div>

--- a/frontend/src/pages/public/ApplyCompletePage.tsx
+++ b/frontend/src/pages/public/ApplyCompletePage.tsx
@@ -1,18 +1,88 @@
+import { Link, useLocation } from 'react-router';
+import { CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ROUTES } from '@/constants';
+import type { ApplyCompleteState } from '@/types';
+
+function formatYen(n: number) {
+  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(n);
+}
+
+function formatDate(iso: string) {
+  try {
+    const d = new Date(iso + 'T00:00:00');
+    return new Intl.DateTimeFormat('ja-JP', { dateStyle: 'long' }).format(d);
+  } catch {
+    return iso;
+  }
+}
+
+function isApplyCompleteState(x: unknown): x is ApplyCompleteState {
+  return (
+    typeof x === 'object' &&
+    x !== null &&
+    'courseName' in x &&
+    'amount' in x &&
+    'paymentDueDate' in x &&
+    typeof (x as ApplyCompleteState).courseName === 'string' &&
+    typeof (x as ApplyCompleteState).amount === 'number' &&
+    typeof (x as ApplyCompleteState).paymentDueDate === 'string'
+  );
+}
 
 export function ApplyCompletePage() {
+  const location = useLocation();
+  const state = isApplyCompleteState(location.state) ? location.state : null;
+
   return (
-    <div className="flex min-h-screen items-center justify-center p-8">
-      <Card className="w-full max-w-md text-center">
-        <CardHeader>
-          <CardTitle>申し込み完了</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground">
-            お申し込みありがとうございます。確認メールをお送りしましたのでご確認ください。
-          </p>
-        </CardContent>
-      </Card>
+    <div className="min-h-screen bg-gradient-to-b from-muted/40 to-background px-4 py-12 md:py-16">
+      <div className="mx-auto max-w-lg">
+        <Card className="border-border/80 shadow-sm">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex size-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <CheckCircle2 className="size-8" />
+            </div>
+            <CardTitle className="text-2xl">お申し込みを受け付けました</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6 text-center">
+            <p className="text-muted-foreground text-pretty leading-relaxed">
+              この度はお申し込みいただき、ありがとうございます。内容を確認のうえ、ご登録のメールアドレスへご連絡いたします。
+            </p>
+
+            {state ? (
+              <div className="rounded-lg border bg-muted/40 px-4 py-3 text-left text-sm">
+                <p className="font-medium text-foreground">お申し込み内容</p>
+                <ul className="mt-2 space-y-1 text-muted-foreground">
+                  <li>
+                    コース: <span className="text-foreground">{state.courseName}</span>
+                  </li>
+                  <li>
+                    お支払い金額: <span className="text-foreground">{formatYen(state.amount)}</span>
+                  </li>
+                  <li>
+                    お支払い期限（目安）:{' '}
+                    <span className="text-foreground">{formatDate(state.paymentDueDate)}</span>
+                  </li>
+                </ul>
+              </div>
+            ) : null}
+
+            <div className="space-y-3 text-left text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">今後の流れ</p>
+              <ol className="list-decimal space-y-2 pl-5">
+                <li>ご入金のご案内（メール等でお知らせします）</li>
+                <li>入金確認後、ヒアリングのご案内をお送りします</li>
+                <li>ヒアリング後、受講開始に向けた準備を進めます</li>
+              </ol>
+            </div>
+
+            <Button asChild className="w-full" size="lg">
+              <Link to={ROUTES.LOGIN}>運営ログインはこちら</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/public/ApplyCompletePage.tsx
+++ b/frontend/src/pages/public/ApplyCompletePage.tsx
@@ -4,10 +4,11 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { formatYen } from '@/lib/utils';
 import type { ApplyCompleteState } from '@/types';
 
+/** バックエンドの日付は Asia/Tokyo 基準のため、表示も JST の暦日として解釈する */
 function formatDate(iso: string) {
   try {
-    const d = new Date(iso + 'T00:00:00');
-    return new Intl.DateTimeFormat('ja-JP', { dateStyle: 'long' }).format(d);
+    const d = new Date(`${iso}T00:00:00+09:00`);
+    return new Intl.DateTimeFormat('ja-JP', { dateStyle: 'long', timeZone: 'Asia/Tokyo' }).format(d);
   } catch {
     return iso;
   }

--- a/frontend/src/pages/public/ApplyCompletePage.tsx
+++ b/frontend/src/pages/public/ApplyCompletePage.tsx
@@ -1,11 +1,8 @@
 import { useLocation } from 'react-router';
 import { CheckCircle2 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatYen } from '@/lib/utils';
 import type { ApplyCompleteState } from '@/types';
-
-function formatYen(n: number) {
-  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(n);
-}
 
 function formatDate(iso: string) {
   try {

--- a/frontend/src/pages/public/ApplyPage.tsx
+++ b/frontend/src/pages/public/ApplyPage.tsx
@@ -88,6 +88,7 @@ export function ApplyPage() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (applyMutation.isPending) return;
     if (!validateStep2() || selectedCourseId == null) return;
 
     applyMutation.mutate({

--- a/frontend/src/pages/public/ApplyPage.tsx
+++ b/frontend/src/pages/public/ApplyPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 import { ArrowLeft, ArrowRight, Check, Loader2 } from 'lucide-react';
@@ -52,14 +52,15 @@ export function ApplyPage() {
   const applyMutation = useMutation({
     mutationFn: submitApplication,
     onSuccess: (data) => {
-      const state: ApplyCompleteState = {
-        courseName: data.courseName,
-        amount: data.amount,
-        paymentDueDate: data.paymentDueDate,
-      };
-      navigate(ROUTES.APPLY_COMPLETE, { state });
+      navigate(ROUTES.APPLY_COMPLETE, { state: data satisfies ApplyCompleteState });
     },
   });
+
+  useEffect(() => {
+    if (step === 2 && selectedCourseId == null) {
+      setStep(1);
+    }
+  }, [step, selectedCourseId]);
 
   const validateStep1 = () => {
     if (selectedCourseId == null) {

--- a/frontend/src/pages/public/ApplyPage.tsx
+++ b/frontend/src/pages/public/ApplyPage.tsx
@@ -16,17 +16,13 @@ import {
 import { ROUTES } from '@/constants';
 import { fetchApplyCourses, fetchApplyReferralSources, submitApplication } from '@/lib/api/apply';
 import { getApiErrorMessage, getApiValidationErrors } from '@/lib/api/errors';
-import { cn } from '@/lib/utils';
+import { cn, formatYen } from '@/lib/utils';
 import type { ApplyCompleteState, ApplyCourse } from '@/types';
 
 const EMPTY_REFERRAL = '__EMPTY__';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PHONE_RE = /^$|^[0-9+()\-\s]{8,20}$/;
-
-function formatYen(n: number) {
-  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(n);
-}
 
 export function ApplyPage() {
   const navigate = useNavigate();

--- a/frontend/src/pages/public/ApplyPage.tsx
+++ b/frontend/src/pages/public/ApplyPage.tsx
@@ -1,8 +1,358 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
+import { ArrowLeft, ArrowRight, Check, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ROUTES } from '@/constants';
+import { fetchApplyCourses, fetchApplyReferralSources, submitApplication } from '@/lib/api/apply';
+import { getApiErrorMessage, getApiValidationErrors } from '@/lib/api/errors';
+import { cn } from '@/lib/utils';
+import type { ApplyCompleteState, ApplyCourse } from '@/types';
+
+const EMPTY_REFERRAL = '__EMPTY__';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^$|^[0-9+()\-\s]{8,20}$/;
+
+function formatYen(n: number) {
+  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(n);
+}
+
 export function ApplyPage() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<1 | 2>(1);
+  const [selectedCourseId, setSelectedCourseId] = useState<number | null>(null);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [referralSourceId, setReferralSourceId] = useState<string>(EMPTY_REFERRAL);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const coursesQuery = useQuery({
+    queryKey: ['apply-courses'],
+    queryFn: fetchApplyCourses,
+  });
+
+  const referralQuery = useQuery({
+    queryKey: ['apply-referral-sources'],
+    queryFn: fetchApplyReferralSources,
+  });
+
+  const selectedCourse = useMemo(
+    () => coursesQuery.data?.find((c) => c.id === selectedCourseId) ?? null,
+    [coursesQuery.data, selectedCourseId],
+  );
+
+  const applyMutation = useMutation({
+    mutationFn: submitApplication,
+    onSuccess: (data) => {
+      const state: ApplyCompleteState = {
+        courseName: data.courseName,
+        amount: data.amount,
+        paymentDueDate: data.paymentDueDate,
+      };
+      navigate(ROUTES.APPLY_COMPLETE, { state });
+    },
+  });
+
+  const validateStep1 = () => {
+    if (selectedCourseId == null) {
+      setFieldErrors({ courseId: 'コースを選択してください' });
+      return false;
+    }
+    setFieldErrors({});
+    return true;
+  };
+
+  const validateStep2 = () => {
+    const next: Record<string, string> = {};
+    if (!name.trim()) next.name = '氏名は必須です';
+    if (!email.trim()) next.email = 'メールアドレスは必須です';
+    else if (!EMAIL_RE.test(email.trim())) next.email = 'メールアドレスの形式が不正です';
+    if (phone.trim() && !PHONE_RE.test(phone.trim())) next.phone = '電話番号の形式が不正です';
+    if (referralSourceId === EMPTY_REFERRAL) next.referralSourceId = '申込経路を選択してください';
+
+    setFieldErrors(next);
+    return Object.keys(next).length === 0;
+  };
+
+  const handleNext = () => {
+    if (validateStep1()) setStep(2);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validateStep2() || selectedCourseId == null) return;
+
+    applyMutation.mutate({
+      name: name.trim(),
+      email: email.trim(),
+      phone: phone.trim(),
+      courseId: selectedCourseId,
+      referralSourceId: Number(referralSourceId),
+    });
+  };
+
+  const apiValidation = applyMutation.isError ? getApiValidationErrors(applyMutation.error) : {};
+  const mergedErrors = { ...fieldErrors, ...apiValidation };
+
   return (
-    <div className="mx-auto max-w-2xl space-y-6 p-8">
-      <h1 className="text-3xl font-bold">受講申し込み</h1>
-      <p className="text-muted-foreground">（未実装）コース選択と受講生情報の入力フォームを実装予定</p>
+    <div className="min-h-screen bg-gradient-to-b from-muted/40 to-background">
+      <div className="mx-auto max-w-3xl space-y-8 px-4 py-10 md:py-14">
+        <header className="space-y-2 text-center">
+          <h1 className="text-3xl font-bold tracking-tight md:text-4xl">受講お申し込み</h1>
+          <p className="text-muted-foreground text-pretty">
+            コースをお選びいただき、必要事項をご入力ください。
+          </p>
+        </header>
+
+        <ol className="flex items-center justify-center gap-2 text-sm">
+          <StepBadge active={step === 1} done={step > 1} label="コース選択" step={1} />
+          <span className="text-muted-foreground">—</span>
+          <StepBadge active={step === 2} done={false} label="お客様情報" step={2} />
+        </ol>
+
+        {coursesQuery.isLoading || referralQuery.isLoading ? (
+          <Card>
+            <CardContent className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+              <Loader2 className="size-5 animate-spin" />
+              読み込み中...
+            </CardContent>
+          </Card>
+        ) : coursesQuery.isError ? (
+          <Card>
+            <CardContent className="py-8 text-center text-destructive">
+              {getApiErrorMessage(coursesQuery.error, 'コース一覧の取得に失敗しました')}
+            </CardContent>
+          </Card>
+        ) : referralQuery.isError ? (
+          <Card>
+            <CardContent className="py-8 text-center text-destructive">
+              {getApiErrorMessage(referralQuery.error, '申込経路の取得に失敗しました')}
+            </CardContent>
+          </Card>
+        ) : step === 1 ? (
+          <section className="space-y-4">
+            <CourseGrid
+              courses={coursesQuery.data ?? []}
+              selectedId={selectedCourseId}
+              onSelect={setSelectedCourseId}
+            />
+            {mergedErrors.courseId && (
+              <p className="text-center text-sm text-destructive">{mergedErrors.courseId}</p>
+            )}
+            <div className="flex justify-end">
+              <Button type="button" size="lg" onClick={handleNext} disabled={!coursesQuery.data?.length}>
+                次へ
+                <ArrowRight className="ml-2 size-4" />
+              </Button>
+            </div>
+          </section>
+        ) : (
+          <Card className="border-border/80 shadow-sm">
+            <CardHeader>
+              <CardTitle>お客様情報</CardTitle>
+              <CardDescription>
+                選択中のコース: <span className="font-medium text-foreground">{selectedCourse?.name}</span>
+                {selectedCourse != null && (
+                  <span className="ml-2">{formatYen(selectedCourse.price)}</span>
+                )}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleSubmit} className="space-y-6">
+                {applyMutation.isError && (
+                  <div
+                    role="alert"
+                    className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+                  >
+                    {getApiErrorMessage(applyMutation.error, '送信に失敗しました')}
+                  </div>
+                )}
+
+                <div className="space-y-2">
+                  <Label htmlFor="apply-name">氏名</Label>
+                  <Input
+                    id="apply-name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    autoComplete="name"
+                    maxLength={100}
+                    aria-invalid={!!mergedErrors.name}
+                  />
+                  {mergedErrors.name && <p className="text-sm text-destructive">{mergedErrors.name}</p>}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="apply-email">メールアドレス</Label>
+                  <Input
+                    id="apply-email"
+                    type="email"
+                    inputMode="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    autoComplete="email"
+                    aria-invalid={!!mergedErrors.email}
+                  />
+                  {mergedErrors.email && <p className="text-sm text-destructive">{mergedErrors.email}</p>}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="apply-phone">電話番号（任意）</Label>
+                  <Input
+                    id="apply-phone"
+                    type="tel"
+                    inputMode="tel"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                    autoComplete="tel"
+                    placeholder="例: 090-1234-5678"
+                    aria-invalid={!!mergedErrors.phone}
+                  />
+                  {mergedErrors.phone && <p className="text-sm text-destructive">{mergedErrors.phone}</p>}
+                </div>
+
+                <div className="space-y-2">
+                  <Label>申込経路</Label>
+                  <Select value={referralSourceId} onValueChange={setReferralSourceId}>
+                    <SelectTrigger aria-invalid={!!mergedErrors.referralSourceId}>
+                      <SelectValue placeholder="選択してください" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(referralQuery.data ?? []).map((r) => (
+                        <SelectItem key={r.id} value={String(r.id)}>
+                          <span className="text-muted-foreground mr-2 text-xs">[{r.category}]</span>
+                          {r.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {mergedErrors.referralSourceId && (
+                    <p className="text-sm text-destructive">{mergedErrors.referralSourceId}</p>
+                  )}
+                </div>
+
+                <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-between">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setStep(1);
+                      setFieldErrors({});
+                      applyMutation.reset();
+                    }}
+                  >
+                    <ArrowLeft className="mr-2 size-4" />
+                    戻る
+                  </Button>
+                  <Button type="submit" size="lg" disabled={applyMutation.isPending}>
+                    {applyMutation.isPending ? (
+                      <>
+                        <Loader2 className="mr-2 size-4 animate-spin" />
+                        送信中...
+                      </>
+                    ) : (
+                      '申し込む'
+                    )}
+                  </Button>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StepBadge({
+  step,
+  label,
+  active,
+  done,
+}: {
+  step: number;
+  label: string;
+  active: boolean;
+  done: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 rounded-full border px-3 py-1.5',
+        active && 'border-primary bg-primary/10 text-primary',
+        done && !active && 'border-muted-foreground/30 text-muted-foreground',
+        !active && !done && 'border-muted text-muted-foreground',
+      )}
+    >
+      <span
+        className={cn(
+          'flex size-6 items-center justify-center rounded-full text-xs font-semibold',
+          active && 'bg-primary text-primary-foreground',
+          done && 'bg-muted-foreground/20 text-foreground',
+          !active && !done && 'bg-muted',
+        )}
+      >
+        {done ? <Check className="size-3.5" /> : step}
+      </span>
+      <span className="hidden sm:inline">{label}</span>
+    </div>
+  );
+}
+
+function CourseGrid({
+  courses,
+  selectedId,
+  onSelect,
+}: {
+  courses: ApplyCourse[];
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+}) {
+  if (courses.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-muted-foreground">
+          現在お申し込みいただけるコースがありません。しばらくしてから再度ご確認ください。
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {courses.map((course) => {
+        const selected = selectedId === course.id;
+        return (
+          <button
+            key={course.id}
+            type="button"
+            onClick={() => onSelect(course.id)}
+            className={cn(
+              'rounded-xl border-2 p-5 text-left transition-colors hover:border-primary/50',
+              selected ? 'border-primary bg-primary/5 shadow-sm' : 'border-border bg-card',
+            )}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <h2 className="text-lg font-semibold leading-snug">{course.name}</h2>
+              <span className="shrink-0 text-sm font-medium text-primary">{formatYen(course.price)}</span>
+            </div>
+            {course.description ? (
+              <p className="mt-2 line-clamp-3 text-sm text-muted-foreground">{course.description}</p>
+            ) : null}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/pages/public/ApplyPage.tsx
+++ b/frontend/src/pages/public/ApplyPage.tsx
@@ -203,6 +203,7 @@ export function ApplyPage() {
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     autoComplete="email"
+                    maxLength={255}
                     aria-invalid={!!mergedErrors.email}
                   />
                   {mergedErrors.email && <p className="text-sm text-destructive">{mergedErrors.email}</p>}
@@ -218,6 +219,7 @@ export function ApplyPage() {
                     onChange={(e) => setPhone(e.target.value)}
                     autoComplete="tel"
                     placeholder="例: 090-1234-5678"
+                    maxLength={20}
                     aria-invalid={!!mergedErrors.phone}
                   />
                   {mergedErrors.phone && <p className="text-sm text-destructive">{mergedErrors.phone}</p>}

--- a/frontend/src/pages/public/ApplyPage.tsx
+++ b/frontend/src/pages/public/ApplyPage.tsx
@@ -83,7 +83,10 @@ export function ApplyPage() {
   };
 
   const handleNext = () => {
-    if (validateStep1()) setStep(2);
+    if (validateStep1()) {
+      applyMutation.reset();
+      setStep(2);
+    }
   };
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -224,9 +224,5 @@ export interface ApplyResult {
   paymentDueDate: string;
 }
 
-/** 申込完了画面へ渡す状態 */
-export interface ApplyCompleteState {
-  courseName: string;
-  amount: number;
-  paymentDueDate: string;
-}
+/** 申込完了画面へ渡す状態（API レスポンスと同一形状） */
+export type ApplyCompleteState = ApplyResult;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -217,11 +217,8 @@ export interface ApplyInput {
   referralSourceId: number;
 }
 
-/** 公開申込 API レスポンス */
+/** 公開申込 API レスポンス（内部 ID は含まない） */
 export interface ApplyResult {
-  studentId: number;
-  enrollmentId: number;
-  paymentId: number;
   courseName: string;
   amount: number;
   paymentDueDate: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -199,3 +199,37 @@ export interface ReferralSourceOption {
   name: string;
   category: string;
 }
+
+/** 公開申込フォーム用コース */
+export interface ApplyCourse {
+  id: number;
+  name: string;
+  description: string | null;
+  price: number;
+}
+
+/** 公開申込送信ペイロード */
+export interface ApplyInput {
+  name: string;
+  email: string;
+  phone: string;
+  courseId: number;
+  referralSourceId: number;
+}
+
+/** 公開申込 API レスポンス */
+export interface ApplyResult {
+  studentId: number;
+  enrollmentId: number;
+  paymentId: number;
+  courseName: string;
+  amount: number;
+  paymentDueDate: string;
+}
+
+/** 申込完了画面へ渡す状態 */
+export interface ApplyCompleteState {
+  courseName: string;
+  amount: number;
+  paymentDueDate: string;
+}


### PR DESCRIPTION
## 概要
公開申込フォーム（APP-001/002）を実装しました。申込時に \Student\・\Enrollment\・\Payment\ を同一トランザクションで作成します。

## バックエンド
- \GET /api/apply/courses\ … 公開コース一覧
- \GET /api/apply/referral-sources\ … 申込経路（既存マスタと同内容）
- \POST /api/apply\ … 申込（受講生 PROVISIONAL、受講 ENROLLED、決済 UNPAID、期日は申込日+30日）
- \ApplyServiceTest\ で正常系・異常系を検証

## フロントエンド
- \/apply\ … コース選択 → お客様情報・申込経路入力 → 送信
- \/apply/complete\ … 完了メッセージと今後の流れ

## 確認
- \
pm run build\ / \
pm run lint\ 成功
- バックエンドはローカルに Maven が無いため \mvn test\ は未実行（CI で確認してください）

Closes #26

Made with [Cursor](https://cursor.com)