### PR TITLE
feat: Phase7-A 運営メンバー管理機能とパスワード変更 (#30)

### DIFF
--- a/backend/src/main/java/com/student/management/controller/AuthController.java
+++ b/backend/src/main/java/com/student/management/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.student.management.controller;
 
+import com.student.management.dto.auth.ChangePasswordRequest;
 import com.student.management.dto.auth.LoginRequest;
 import com.student.management.dto.auth.RefreshRequest;
 import com.student.management.dto.auth.TokenResponse;
@@ -7,6 +8,7 @@ import com.student.management.dto.auth.UserResponse;
 import com.student.management.service.AuthService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,5 +44,16 @@ public class AuthController {
     public ResponseEntity<UserResponse> me(@AuthenticationPrincipal UserDetails userDetails) {
         UserResponse response = authService.getCurrentUser(userDetails.getUsername());
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/password")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> changePassword(@AuthenticationPrincipal UserDetails userDetails,
+                                               @Valid @RequestBody ChangePasswordRequest request) {
+        authService.changePassword(
+                userDetails.getUsername(),
+                request.getCurrentPassword(),
+                request.getNewPassword());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/student/management/controller/UserController.java
+++ b/backend/src/main/java/com/student/management/controller/UserController.java
@@ -1,0 +1,76 @@
+package com.student.management.controller;
+
+import com.student.management.dto.user.PasswordResetRequest;
+import com.student.management.dto.user.UserCreateRequest;
+import com.student.management.dto.user.UserDetailResponse;
+import com.student.management.dto.user.UserListItemResponse;
+import com.student.management.dto.user.UserUpdateRequest;
+import com.student.management.security.CustomUserDetails;
+import com.student.management.service.UserManagementService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+@PreAuthorize("hasRole('ADMIN')")
+public class UserController {
+
+    private final UserManagementService userManagementService;
+
+    public UserController(UserManagementService userManagementService) {
+        this.userManagementService = userManagementService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<UserListItemResponse>> list(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String role) {
+        return ResponseEntity.ok(userManagementService.getUsers(keyword, role));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UserDetailResponse> get(@PathVariable Long id) {
+        return ResponseEntity.ok(userManagementService.getUser(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<UserDetailResponse> create(@Valid @RequestBody UserCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(userManagementService.createUser(request));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<UserDetailResponse> update(@PathVariable Long id,
+                                                     @Valid @RequestBody UserUpdateRequest request) {
+        return ResponseEntity.ok(userManagementService.updateUser(id, request));
+    }
+
+    @PostMapping("/{id}/password-reset")
+    public ResponseEntity<Void> resetPassword(@PathVariable Long id,
+                                              @Valid @RequestBody PasswordResetRequest request) {
+        userManagementService.resetPassword(id, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id,
+                                       @AuthenticationPrincipal CustomUserDetails principal) {
+        Long currentUserId = principal != null && principal.getUser() != null
+                ? principal.getUser().getId() : null;
+        userManagementService.deleteUser(id, currentUserId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/student/management/dto/auth/ChangePasswordRequest.java
+++ b/backend/src/main/java/com/student/management/dto/auth/ChangePasswordRequest.java
@@ -1,0 +1,22 @@
+package com.student.management.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class ChangePasswordRequest {
+
+    @NotBlank(message = "現在のパスワードは必須です")
+    @Size(max = 128, message = "現在のパスワードは128文字以内で入力してください")
+    private String currentPassword;
+
+    @NotBlank(message = "新しいパスワードは必須です")
+    @Size(min = 8, max = 128, message = "新しいパスワードは8〜128文字で入力してください")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?`~]+$",
+            message = "新しいパスワードは英字と数字を両方含めてください"
+    )
+    private String newPassword;
+}

--- a/backend/src/main/java/com/student/management/dto/user/PasswordResetRequest.java
+++ b/backend/src/main/java/com/student/management/dto/user/PasswordResetRequest.java
@@ -1,0 +1,16 @@
+package com.student.management.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record PasswordResetRequest(
+        @NotBlank(message = "新しいパスワードは必須です")
+        @Size(min = 8, max = 128, message = "パスワードは8〜128文字で入力してください")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?`~]+$",
+                message = "パスワードは英字と数字を両方含めてください"
+        )
+        String newPassword
+) {
+}

--- a/backend/src/main/java/com/student/management/dto/user/UserCreateRequest.java
+++ b/backend/src/main/java/com/student/management/dto/user/UserCreateRequest.java
@@ -1,0 +1,35 @@
+package com.student.management.dto.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserCreateRequest(
+        @NotBlank(message = "ユーザー名は必須です")
+        @Size(min = 3, max = 50, message = "ユーザー名は3〜50文字で入力してください")
+        @Pattern(regexp = "^[A-Za-z0-9._-]+$", message = "ユーザー名は半角英数字と . _ - のみ使用できます")
+        String username,
+
+        @NotBlank(message = "メールアドレスは必須です")
+        @Email(message = "メールアドレスの形式が正しくありません")
+        @Size(max = 255, message = "メールアドレスは255文字以内で入力してください")
+        String email,
+
+        @NotBlank(message = "氏名は必須です")
+        @Size(max = 100, message = "氏名は100文字以内で入力してください")
+        String name,
+
+        @NotBlank(message = "ロールは必須です")
+        @Pattern(regexp = "^(ADMIN|STAFF|INSTRUCTOR)$", message = "ロールは ADMIN/STAFF/INSTRUCTOR のいずれかです")
+        String role,
+
+        @NotBlank(message = "パスワードは必須です")
+        @Size(min = 8, max = 128, message = "パスワードは8〜128文字で入力してください")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?`~]+$",
+                message = "パスワードは英字と数字を両方含めてください"
+        )
+        String password
+) {
+}

--- a/backend/src/main/java/com/student/management/dto/user/UserDetailResponse.java
+++ b/backend/src/main/java/com/student/management/dto/user/UserDetailResponse.java
@@ -1,0 +1,27 @@
+package com.student.management.dto.user;
+
+import com.student.management.entity.User;
+
+import java.time.LocalDateTime;
+
+public record UserDetailResponse(
+        Long id,
+        String username,
+        String email,
+        String name,
+        String role,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static UserDetailResponse from(User user) {
+        return new UserDetailResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                user.getName(),
+                user.getRole(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/student/management/dto/user/UserListItemResponse.java
+++ b/backend/src/main/java/com/student/management/dto/user/UserListItemResponse.java
@@ -1,0 +1,27 @@
+package com.student.management.dto.user;
+
+import com.student.management.entity.User;
+
+import java.time.LocalDateTime;
+
+public record UserListItemResponse(
+        Long id,
+        String username,
+        String email,
+        String name,
+        String role,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static UserListItemResponse from(User user) {
+        return new UserListItemResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                user.getName(),
+                user.getRole(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/student/management/dto/user/UserUpdateRequest.java
+++ b/backend/src/main/java/com/student/management/dto/user/UserUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.student.management.dto.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserUpdateRequest(
+        @NotBlank(message = "メールアドレスは必須です")
+        @Email(message = "メールアドレスの形式が正しくありません")
+        @Size(max = 255, message = "メールアドレスは255文字以内で入力してください")
+        String email,
+
+        @NotBlank(message = "氏名は必須です")
+        @Size(max = 100, message = "氏名は100文字以内で入力してください")
+        String name,
+
+        @NotBlank(message = "ロールは必須です")
+        @Pattern(regexp = "^(ADMIN|STAFF|INSTRUCTOR)$", message = "ロールは ADMIN/STAFF/INSTRUCTOR のいずれかです")
+        String role
+) {
+}

--- a/backend/src/main/java/com/student/management/entity/User.java
+++ b/backend/src/main/java/com/student/management/entity/User.java
@@ -14,4 +14,5 @@ public class User {
     private String role;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
 }

--- a/backend/src/main/java/com/student/management/repository/UserMapper.java
+++ b/backend/src/main/java/com/student/management/repository/UserMapper.java
@@ -16,5 +16,23 @@ public interface UserMapper {
 
     boolean existsByUsername(@Param("username") String username);
 
+    boolean existsByEmail(@Param("email") String email);
+
+    boolean existsByUsernameExceptId(@Param("username") String username, @Param("id") Long id);
+
+    boolean existsByEmailExceptId(@Param("email") String email, @Param("id") Long id);
+
     List<User> findByRole(@Param("role") String role);
+
+    List<User> findAll(@Param("keyword") String keyword, @Param("role") String role);
+
+    long countActiveAdmins();
+
+    void insert(User user);
+
+    int update(User user);
+
+    int updatePassword(@Param("id") Long id, @Param("passwordHash") String passwordHash);
+
+    int softDelete(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/student/management/service/AuthService.java
+++ b/backend/src/main/java/com/student/management/service/AuthService.java
@@ -81,4 +81,23 @@ public class AuthService {
                         HttpStatus.NOT_FOUND, "ユーザーが見つかりません"));
         return UserResponse.from(user);
     }
+
+    @Transactional
+    public void changePassword(String username, String currentPassword, String newPassword) {
+        User user = userMapper.findByUsername(username)
+                .orElseThrow(() -> new ApiException(
+                        HttpStatus.NOT_FOUND, "ユーザーが見つかりません"));
+
+        if (!passwordEncoder.matches(currentPassword, user.getPasswordHash())) {
+            log.warn("パスワード変更失敗（現在のパスワード不一致）: username={}", username);
+            throw new ApiException(HttpStatus.BAD_REQUEST, "現在のパスワードが正しくありません");
+        }
+
+        if (passwordEncoder.matches(newPassword, user.getPasswordHash())) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "新しいパスワードは現在のパスワードと異なる必要があります");
+        }
+
+        userMapper.updatePassword(user.getId(), passwordEncoder.encode(newPassword));
+        log.info("パスワード変更成功: userId={}, username={}", user.getId(), username);
+    }
 }

--- a/backend/src/main/java/com/student/management/service/UserManagementService.java
+++ b/backend/src/main/java/com/student/management/service/UserManagementService.java
@@ -1,0 +1,121 @@
+package com.student.management.service;
+
+import com.student.management.dto.user.PasswordResetRequest;
+import com.student.management.dto.user.UserCreateRequest;
+import com.student.management.dto.user.UserDetailResponse;
+import com.student.management.dto.user.UserListItemResponse;
+import com.student.management.dto.user.UserUpdateRequest;
+import com.student.management.entity.User;
+import com.student.management.exception.ApiException;
+import com.student.management.repository.UserMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class UserManagementService {
+
+    private static final String ROLE_ADMIN = "ADMIN";
+
+    private final UserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserManagementService(UserMapper userMapper, PasswordEncoder passwordEncoder) {
+        this.userMapper = userMapper;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public List<UserListItemResponse> getUsers(String keyword, String role) {
+        return userMapper.findAll(normalize(keyword), normalize(role)).stream()
+                .map(UserListItemResponse::from)
+                .toList();
+    }
+
+    public UserDetailResponse getUser(Long id) {
+        return UserDetailResponse.from(loadUser(id));
+    }
+
+    @Transactional
+    public UserDetailResponse createUser(UserCreateRequest request) {
+        String username = request.username().trim();
+        String email = request.email().trim();
+
+        if (userMapper.existsByUsername(username)) {
+            throw new ApiException(HttpStatus.CONFLICT, "このユーザー名はすでに使用されています");
+        }
+        if (userMapper.existsByEmail(email)) {
+            throw new ApiException(HttpStatus.CONFLICT, "このメールアドレスはすでに使用されています");
+        }
+
+        User user = new User();
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setName(request.name().trim());
+        user.setRole(request.role());
+        user.setPasswordHash(passwordEncoder.encode(request.password()));
+
+        userMapper.insert(user);
+        return UserDetailResponse.from(loadUser(user.getId()));
+    }
+
+    @Transactional
+    public UserDetailResponse updateUser(Long id, UserUpdateRequest request) {
+        User user = loadUser(id);
+
+        String email = request.email().trim();
+        if (userMapper.existsByEmailExceptId(email, id)) {
+            throw new ApiException(HttpStatus.CONFLICT, "このメールアドレスはすでに使用されています");
+        }
+
+        boolean roleChangedFromAdmin = ROLE_ADMIN.equals(user.getRole())
+                && !ROLE_ADMIN.equals(request.role());
+        if (roleChangedFromAdmin && userMapper.countActiveAdmins() <= 1) {
+            throw new ApiException(HttpStatus.CONFLICT, "最後の管理者のロールは変更できません");
+        }
+
+        user.setEmail(email);
+        user.setName(request.name().trim());
+        user.setRole(request.role());
+
+        userMapper.update(user);
+        return UserDetailResponse.from(loadUser(id));
+    }
+
+    @Transactional
+    public void resetPassword(Long id, PasswordResetRequest request) {
+        loadUser(id);
+        userMapper.updatePassword(id, passwordEncoder.encode(request.newPassword()));
+    }
+
+    @Transactional
+    public void deleteUser(Long id, Long currentUserId) {
+        User user = loadUser(id);
+
+        if (currentUserId != null && currentUserId.equals(id)) {
+            throw new ApiException(HttpStatus.CONFLICT, "自分自身は削除できません");
+        }
+
+        if (ROLE_ADMIN.equals(user.getRole()) && userMapper.countActiveAdmins() <= 1) {
+            throw new ApiException(HttpStatus.CONFLICT, "最後の管理者は削除できません");
+        }
+
+        userMapper.softDelete(id);
+    }
+
+    private User loadUser(Long id) {
+        return userMapper.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "ユーザーが見つかりません"));
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/backend/src/main/resources/db/migration/V7__users_soft_delete.sql
+++ b/backend/src/main/resources/db/migration/V7__users_soft_delete.sql
@@ -1,0 +1,5 @@
+-- ユーザーの論理削除カラムを追加する
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP NULL;
+
+CREATE INDEX IF NOT EXISTS idx_users_deleted_at ON users (deleted_at);

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -4,30 +4,119 @@
 <mapper namespace="com.student.management.repository.UserMapper">
 
     <sql id="userColumns">
-        id, username, email, password_hash, name, role, created_at, updated_at
+        id, username, email, password_hash, name, role, created_at, updated_at, deleted_at
     </sql>
 
     <select id="findByUsername" resultType="com.student.management.entity.User">
         SELECT <include refid="userColumns"/>
         FROM users
         WHERE username = #{username}
+          AND deleted_at IS NULL
     </select>
 
     <select id="findById" resultType="com.student.management.entity.User">
         SELECT <include refid="userColumns"/>
         FROM users
         WHERE id = #{id}
+          AND deleted_at IS NULL
     </select>
 
     <select id="existsByUsername" resultType="boolean">
-        SELECT EXISTS(SELECT 1 FROM users WHERE username = #{username})
+        SELECT EXISTS(
+            SELECT 1 FROM users
+            WHERE username = #{username}
+              AND deleted_at IS NULL
+        )
+    </select>
+
+    <select id="existsByEmail" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1 FROM users
+            WHERE email = #{email}
+              AND deleted_at IS NULL
+        )
+    </select>
+
+    <select id="existsByUsernameExceptId" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1 FROM users
+            WHERE username = #{username}
+              AND id &lt;&gt; #{id}
+              AND deleted_at IS NULL
+        )
+    </select>
+
+    <select id="existsByEmailExceptId" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1 FROM users
+            WHERE email = #{email}
+              AND id &lt;&gt; #{id}
+              AND deleted_at IS NULL
+        )
     </select>
 
     <select id="findByRole" resultType="com.student.management.entity.User">
         SELECT <include refid="userColumns"/>
         FROM users
         WHERE role = #{role}
+          AND deleted_at IS NULL
         ORDER BY name ASC, id ASC
     </select>
+
+    <select id="findAll" resultType="com.student.management.entity.User">
+        SELECT <include refid="userColumns"/>
+        FROM users
+        WHERE deleted_at IS NULL
+        <if test="role != null and role != ''">
+            AND role = #{role}
+        </if>
+        <if test="keyword != null and keyword != ''">
+            AND (
+                LOWER(username) LIKE '%' || LOWER(#{keyword}) || '%'
+                OR LOWER(email) LIKE '%' || LOWER(#{keyword}) || '%'
+                OR LOWER(name) LIKE '%' || LOWER(#{keyword}) || '%'
+            )
+        </if>
+        ORDER BY role ASC, name ASC, id ASC
+    </select>
+
+    <select id="countActiveAdmins" resultType="long">
+        SELECT COUNT(*)
+        FROM users
+        WHERE role = 'ADMIN'
+          AND deleted_at IS NULL
+    </select>
+
+    <insert id="insert" parameterType="com.student.management.entity.User"
+            useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO users (username, email, password_hash, name, role)
+        VALUES (#{username}, #{email}, #{passwordHash}, #{name}, #{role})
+    </insert>
+
+    <update id="update" parameterType="com.student.management.entity.User">
+        UPDATE users
+        SET email = #{email},
+            name = #{name},
+            role = #{role},
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = #{id}
+          AND deleted_at IS NULL
+    </update>
+
+    <update id="updatePassword">
+        UPDATE users
+        SET password_hash = #{passwordHash},
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = #{id}
+          AND deleted_at IS NULL
+    </update>
+
+    <update id="softDelete">
+        UPDATE users
+        SET deleted_at = CURRENT_TIMESTAMP,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = #{id}
+          AND deleted_at IS NULL
+    </update>
 
 </mapper>

--- a/backend/src/test/java/com/student/management/service/UserManagementServiceTest.java
+++ b/backend/src/test/java/com/student/management/service/UserManagementServiceTest.java
@@ -1,0 +1,182 @@
+package com.student.management.service;
+
+import com.student.management.dto.user.PasswordResetRequest;
+import com.student.management.dto.user.UserCreateRequest;
+import com.student.management.dto.user.UserUpdateRequest;
+import com.student.management.entity.User;
+import com.student.management.exception.ApiException;
+import com.student.management.repository.UserMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserManagementServiceTest {
+
+    @Mock
+    private UserMapper userMapper;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserManagementService userManagementService;
+
+    @Test
+    void createUser_hashesPasswordAndInserts() {
+        when(userMapper.existsByUsername("alice")).thenReturn(false);
+        when(userMapper.existsByEmail("alice@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("Pass1234")).thenReturn("HASHED");
+        doAnswer(inv -> {
+            User u = inv.getArgument(0);
+            u.setId(10L);
+            return null;
+        }).when(userMapper).insert(any(User.class));
+        User stored = new User();
+        stored.setId(10L);
+        stored.setUsername("alice");
+        stored.setEmail("alice@example.com");
+        stored.setName("Alice");
+        stored.setRole("STAFF");
+        when(userMapper.findById(10L)).thenReturn(Optional.of(stored));
+
+        var response = userManagementService.createUser(new UserCreateRequest(
+                "alice", "alice@example.com", "Alice", "STAFF", "Pass1234"));
+
+        assertThat(response.id()).isEqualTo(10L);
+        ArgumentCaptor<User> cap = ArgumentCaptor.forClass(User.class);
+        verify(userMapper).insert(cap.capture());
+        assertThat(cap.getValue().getPasswordHash()).isEqualTo("HASHED");
+    }
+
+    @Test
+    void createUser_whenUsernameExists_throwsConflict() {
+        when(userMapper.existsByUsername("alice")).thenReturn(true);
+
+        assertThatThrownBy(() -> userManagementService.createUser(new UserCreateRequest(
+                "alice", "a@example.com", "A", "STAFF", "Pass1234")))
+                .isInstanceOf(ApiException.class)
+                .extracting(ex -> ((ApiException) ex).getStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+
+        verify(userMapper, never()).insert(any());
+    }
+
+    @Test
+    void createUser_whenEmailExists_throwsConflict() {
+        when(userMapper.existsByUsername("alice")).thenReturn(false);
+        when(userMapper.existsByEmail("a@example.com")).thenReturn(true);
+
+        assertThatThrownBy(() -> userManagementService.createUser(new UserCreateRequest(
+                "alice", "a@example.com", "A", "STAFF", "Pass1234")))
+                .isInstanceOf(ApiException.class)
+                .extracting(ex -> ((ApiException) ex).getStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void deleteUser_self_throwsConflict() {
+        User self = adminUser(5L);
+        when(userMapper.findById(5L)).thenReturn(Optional.of(self));
+
+        assertThatThrownBy(() -> userManagementService.deleteUser(5L, 5L))
+                .isInstanceOf(ApiException.class)
+                .extracting(ex -> ((ApiException) ex).getStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+
+        verify(userMapper, never()).softDelete(anyLong());
+    }
+
+    @Test
+    void deleteUser_lastAdmin_throwsConflict() {
+        User admin = adminUser(7L);
+        when(userMapper.findById(7L)).thenReturn(Optional.of(admin));
+        when(userMapper.countActiveAdmins()).thenReturn(1L);
+
+        assertThatThrownBy(() -> userManagementService.deleteUser(7L, 8L))
+                .isInstanceOf(ApiException.class)
+                .extracting(ex -> ((ApiException) ex).getStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+
+        verify(userMapper, never()).softDelete(anyLong());
+    }
+
+    @Test
+    void deleteUser_whenAdminWithSiblings_softDeletes() {
+        User admin = adminUser(7L);
+        when(userMapper.findById(7L)).thenReturn(Optional.of(admin));
+        when(userMapper.countActiveAdmins()).thenReturn(2L);
+
+        userManagementService.deleteUser(7L, 8L);
+
+        verify(userMapper).softDelete(7L);
+    }
+
+    @Test
+    void deleteUser_whenStaff_softDeletesWithoutAdminCount() {
+        User staff = new User();
+        staff.setId(9L);
+        staff.setRole("STAFF");
+        when(userMapper.findById(9L)).thenReturn(Optional.of(staff));
+
+        userManagementService.deleteUser(9L, 8L);
+
+        verify(userMapper).softDelete(9L);
+        verify(userMapper, never()).countActiveAdmins();
+    }
+
+    @Test
+    void updateUser_whenChangingLastAdminRole_throwsConflict() {
+        User admin = adminUser(7L);
+        when(userMapper.findById(7L)).thenReturn(Optional.of(admin));
+        when(userMapper.existsByEmailExceptId("admin@example.com", 7L)).thenReturn(false);
+        when(userMapper.countActiveAdmins()).thenReturn(1L);
+
+        assertThatThrownBy(() -> userManagementService.updateUser(7L,
+                new UserUpdateRequest("admin@example.com", "Admin", "STAFF")))
+                .isInstanceOf(ApiException.class)
+                .extracting(ex -> ((ApiException) ex).getStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+
+        verify(userMapper, never()).update(any());
+    }
+
+    @Test
+    void resetPassword_hashesAndUpdates() {
+        when(userMapper.findById(3L)).thenReturn(Optional.of(adminUser(3L)));
+        when(passwordEncoder.encode("NewPass99")).thenReturn("NEW_HASH");
+
+        userManagementService.resetPassword(3L, new PasswordResetRequest("NewPass99"));
+
+        verify(userMapper).updatePassword(eq(3L), anyString());
+        verify(userMapper).updatePassword(3L, "NEW_HASH");
+    }
+
+    private User adminUser(Long id) {
+        User u = new User();
+        u.setId(id);
+        u.setUsername("admin" + id);
+        u.setEmail("admin@example.com");
+        u.setName("Admin");
+        u.setRole("ADMIN");
+        return u;
+    }
+}

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -1,0 +1,50 @@
+import apiClient from '@/lib/api/client';
+import type {
+  MemberCreateInput,
+  MemberDetail,
+  MemberListItem,
+  MemberUpdateInput,
+  Role,
+} from '@/types';
+
+interface MemberListParams {
+  keyword?: string;
+  role?: Role | '';
+}
+
+export async function fetchMembers(params: MemberListParams = {}) {
+  const response = await apiClient.get<MemberListItem[]>('/users', {
+    params: {
+      keyword: params.keyword || undefined,
+      role: params.role || undefined,
+    },
+  });
+  return response.data;
+}
+
+export async function fetchMember(id: number) {
+  const response = await apiClient.get<MemberDetail>(`/users/${id}`);
+  return response.data;
+}
+
+export async function createMember(input: MemberCreateInput) {
+  const response = await apiClient.post<MemberDetail>('/users', input);
+  return response.data;
+}
+
+export async function updateMember(id: number, input: MemberUpdateInput) {
+  const response = await apiClient.put<MemberDetail>(`/users/${id}`, input);
+  return response.data;
+}
+
+export async function deleteMember(id: number) {
+  await apiClient.delete(`/users/${id}`);
+}
+
+export async function resetMemberPassword(id: number, newPassword: string) {
+  await apiClient.post(`/users/${id}/password-reset`, { newPassword });
+}
+
+export async function changeMyPassword(currentPassword: string, newPassword: string) {
+  await apiClient.post('/auth/password', { currentPassword, newPassword });
+}

--- a/frontend/src/pages/admin/PasswordChangePage.tsx
+++ b/frontend/src/pages/admin/PasswordChangePage.tsx
@@ -1,8 +1,147 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { changeMyPassword } from '@/lib/api/users';
+import { getApiErrorMessage, getApiValidationErrors } from '@/lib/api/errors';
+
+interface PasswordFormState {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+const initialState: PasswordFormState = {
+  currentPassword: '',
+  newPassword: '',
+  confirmPassword: '',
+};
+
 export function PasswordChangePage() {
+  const [form, setForm] = useState<PasswordFormState>(initialState);
+  const [formError, setFormError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [success, setSuccess] = useState('');
+
+  const mutation = useMutation({
+    mutationFn: () => changeMyPassword(form.currentPassword, form.newPassword),
+    onSuccess: () => {
+      setFormError('');
+      setFieldErrors({});
+      setSuccess('パスワードを変更しました。');
+      setForm(initialState);
+    },
+    onError: (error) => {
+      setSuccess('');
+      setFormError(getApiErrorMessage(error, 'パスワードの変更に失敗しました'));
+      setFieldErrors(getApiValidationErrors(error));
+    },
+  });
+
+  const setValue = <K extends keyof PasswordFormState>(
+    key: K,
+    value: PasswordFormState[K],
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError('');
+    setFieldErrors({});
+    setSuccess('');
+
+    if (form.newPassword !== form.confirmPassword) {
+      setFormError('新しいパスワードと確認用パスワードが一致しません。');
+      return;
+    }
+
+    mutation.mutate();
+  };
+
   return (
     <div className="space-y-6">
-      <h2 className="text-3xl font-bold tracking-tight">パスワード変更</h2>
-      <p className="text-muted-foreground">（未実装）パスワード変更フォームを実装予定</p>
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight">パスワード変更</h2>
+        <p className="text-muted-foreground">ご自身のパスワードを変更します。</p>
+      </div>
+
+      <Card className="max-w-xl">
+        <CardHeader>
+          <CardTitle>パスワード変更</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            {formError && (
+              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {formError}
+              </div>
+            )}
+            {success && (
+              <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-700">
+                {success}
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="currentPassword">現在のパスワード</Label>
+              <Input
+                id="currentPassword"
+                type="password"
+                value={form.currentPassword}
+                onChange={(event) => setValue('currentPassword', event.target.value)}
+                autoComplete="current-password"
+                required
+              />
+              {fieldErrors.currentPassword && (
+                <p className="text-sm text-destructive">{fieldErrors.currentPassword}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="newPassword">新しいパスワード</Label>
+              <Input
+                id="newPassword"
+                type="password"
+                value={form.newPassword}
+                onChange={(event) => setValue('newPassword', event.target.value)}
+                autoComplete="new-password"
+                minLength={8}
+                maxLength={128}
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                8文字以上、英字と数字を含めてください。
+              </p>
+              {fieldErrors.newPassword && (
+                <p className="text-sm text-destructive">{fieldErrors.newPassword}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword">新しいパスワード（確認）</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={form.confirmPassword}
+                onChange={(event) => setValue('confirmPassword', event.target.value)}
+                autoComplete="new-password"
+                minLength={8}
+                maxLength={128}
+                required
+              />
+            </div>
+
+            <div>
+              <Button type="submit" disabled={mutation.isPending}>
+                {mutation.isPending ? '変更中...' : 'パスワードを変更'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/pages/admin/members/MemberEditPage.tsx
+++ b/frontend/src/pages/admin/members/MemberEditPage.tsx
@@ -1,8 +1,364 @@
+import { useState } from 'react';
+import { Link, Navigate, useNavigate, useParams } from 'react-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useAuth } from '@/hooks/useAuth';
+import {
+  createMember,
+  fetchMember,
+  resetMemberPassword,
+  updateMember,
+} from '@/lib/api/users';
+import { getApiErrorMessage, getApiValidationErrors } from '@/lib/api/errors';
+import type { MemberDetail, Role } from '@/types';
+
+interface MemberFormState {
+  username: string;
+  email: string;
+  name: string;
+  role: Role;
+  password: string;
+}
+
+const initialFormState: MemberFormState = {
+  username: '',
+  email: '',
+  name: '',
+  role: 'STAFF',
+  password: '',
+};
+
 export function MemberEditPage() {
+  const { id } = useParams();
+  const memberId = id ? Number(id) : null;
+  const isNew = memberId === null;
+
+  const memberQuery = useQuery({
+    queryKey: ['member', memberId],
+    queryFn: () => fetchMember(memberId as number),
+    enabled: !isNew && Number.isFinite(memberId),
+  });
+
+  if (!isNew && !Number.isFinite(memberId)) {
+    return <Navigate to="/members" replace />;
+  }
+
   return (
     <div className="space-y-6">
-      <h2 className="text-3xl font-bold tracking-tight">運営メンバー登録・編集</h2>
-      <p className="text-muted-foreground">（未実装）運営メンバー情報の登録・編集フォームを実装予定</p>
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight">
+            {isNew ? '運営メンバー登録' : '運営メンバー編集'}
+          </h2>
+          <p className="text-muted-foreground">
+            運営メンバーの情報を登録・更新します。
+          </p>
+        </div>
+        <Button variant="outline" asChild>
+          <Link to="/members">戻る</Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{isNew ? '運営メンバー登録' : '運営メンバー編集'}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!isNew && memberQuery.isLoading ? (
+            <p className="text-muted-foreground">読み込み中...</p>
+          ) : !isNew && memberQuery.isError ? (
+            <p className="text-sm text-destructive">
+              {getApiErrorMessage(memberQuery.error, '運営メンバー情報の取得に失敗しました')}
+            </p>
+          ) : (
+            <MemberEditForm
+              key={isNew ? 'new-member' : `edit-member-${memberQuery.data?.id ?? memberId}`}
+              isNew={isNew}
+              memberId={memberId}
+              member={memberQuery.data}
+            />
+          )}
+        </CardContent>
+      </Card>
     </div>
+  );
+}
+
+interface MemberEditFormProps {
+  isNew: boolean;
+  memberId: number | null;
+  member?: MemberDetail;
+}
+
+function MemberEditForm({ isNew, memberId, member }: MemberEditFormProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { user: currentUser } = useAuth();
+
+  const isSelf = !isNew && member?.id === currentUser?.id;
+
+  const [form, setForm] = useState<MemberFormState>(() => {
+    if (member) {
+      return {
+        username: member.username,
+        email: member.email,
+        name: member.name,
+        role: member.role,
+        password: '',
+      };
+    }
+    return initialFormState;
+  });
+
+  const [formError, setFormError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [resetOpen, setResetOpen] = useState(false);
+  const [newPassword, setNewPassword] = useState('');
+  const [resetError, setResetError] = useState('');
+  const [resetSuccess, setResetSuccess] = useState('');
+
+  const saveMutation = useMutation({
+    mutationFn: () => {
+      if (isNew) {
+        return createMember({
+          username: form.username.trim(),
+          email: form.email.trim(),
+          name: form.name.trim(),
+          role: form.role,
+          password: form.password,
+        });
+      }
+      return updateMember(memberId as number, {
+        email: form.email.trim(),
+        name: form.name.trim(),
+        role: form.role,
+      });
+    },
+    onSuccess: async (saved) => {
+      setFormError('');
+      setFieldErrors({});
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['members'] }),
+        queryClient.invalidateQueries({ queryKey: ['member', saved.id] }),
+        queryClient.invalidateQueries({ queryKey: ['instructor-options'] }),
+      ]);
+      navigate('/members');
+    },
+    onError: (error) => {
+      setFormError(getApiErrorMessage(error, '運営メンバーの保存に失敗しました'));
+      setFieldErrors(getApiValidationErrors(error));
+    },
+  });
+
+  const resetMutation = useMutation({
+    mutationFn: (password: string) => resetMemberPassword(memberId as number, password),
+    onSuccess: () => {
+      setResetError('');
+      setResetSuccess('パスワードをリセットしました。');
+      setNewPassword('');
+      setResetOpen(false);
+    },
+    onError: (error) => {
+      setResetSuccess('');
+      setResetError(getApiErrorMessage(error, 'パスワードのリセットに失敗しました'));
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError('');
+    setFieldErrors({});
+    saveMutation.mutate();
+  };
+
+  const setValue = <K extends keyof MemberFormState>(key: K, value: MemberFormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      {formError && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {formError}
+        </div>
+      )}
+      {resetSuccess && (
+        <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-700">
+          {resetSuccess}
+        </div>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="username">ユーザー名</Label>
+          <Input
+            id="username"
+            value={form.username}
+            onChange={(event) => setValue('username', event.target.value)}
+            maxLength={50}
+            required
+            disabled={!isNew}
+          />
+          {!isNew && (
+            <p className="text-xs text-muted-foreground">
+              ユーザー名は登録後に変更できません。
+            </p>
+          )}
+          {fieldErrors.username && (
+            <p className="text-sm text-destructive">{fieldErrors.username}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="name">氏名</Label>
+          <Input
+            id="name"
+            value={form.name}
+            onChange={(event) => setValue('name', event.target.value)}
+            maxLength={100}
+            required
+          />
+          {fieldErrors.name && <p className="text-sm text-destructive">{fieldErrors.name}</p>}
+        </div>
+
+        <div className="space-y-2 md:col-span-2">
+          <Label htmlFor="email">メールアドレス</Label>
+          <Input
+            id="email"
+            type="email"
+            value={form.email}
+            onChange={(event) => setValue('email', event.target.value)}
+            maxLength={255}
+            required
+          />
+          {fieldErrors.email && <p className="text-sm text-destructive">{fieldErrors.email}</p>}
+        </div>
+
+        <div className="space-y-2">
+          <Label>ロール</Label>
+          <Select
+            value={form.role}
+            onValueChange={(value) => setValue('role', value as Role)}
+            disabled={isSelf}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ADMIN">管理者</SelectItem>
+              <SelectItem value="STAFF">スタッフ</SelectItem>
+              <SelectItem value="INSTRUCTOR">講師</SelectItem>
+            </SelectContent>
+          </Select>
+          {isSelf && (
+            <p className="text-xs text-muted-foreground">
+              自分自身のロールは変更できません。
+            </p>
+          )}
+          {fieldErrors.role && <p className="text-sm text-destructive">{fieldErrors.role}</p>}
+        </div>
+
+        {isNew && (
+          <div className="space-y-2">
+            <Label htmlFor="password">初期パスワード</Label>
+            <Input
+              id="password"
+              type="password"
+              value={form.password}
+              onChange={(event) => setValue('password', event.target.value)}
+              minLength={8}
+              maxLength={128}
+              required
+              autoComplete="new-password"
+            />
+            <p className="text-xs text-muted-foreground">
+              8文字以上、英字と数字を含めてください。
+            </p>
+            {fieldErrors.password && (
+              <p className="text-sm text-destructive">{fieldErrors.password}</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button type="submit" disabled={saveMutation.isPending}>
+          {saveMutation.isPending ? '保存中...' : '保存'}
+        </Button>
+        <Button type="button" variant="outline" asChild>
+          <Link to="/members">キャンセル</Link>
+        </Button>
+        {!isNew && (
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              setResetError('');
+              setResetSuccess('');
+              setNewPassword('');
+              setResetOpen(true);
+            }}
+          >
+            パスワードをリセット
+          </Button>
+        )}
+      </div>
+
+      <Dialog open={resetOpen} onOpenChange={setResetOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>パスワードをリセット</DialogTitle>
+            <DialogDescription>
+              新しいパスワードを直接設定します。設定後、本人にパスワードを伝達してください。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="newPassword">新しいパスワード</Label>
+            <Input
+              id="newPassword"
+              type="password"
+              value={newPassword}
+              onChange={(event) => setNewPassword(event.target.value)}
+              minLength={8}
+              maxLength={128}
+              autoComplete="new-password"
+            />
+            <p className="text-xs text-muted-foreground">
+              8文字以上、英字と数字を含めてください。
+            </p>
+            {resetError && <p className="text-sm text-destructive">{resetError}</p>}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setResetOpen(false)}>
+              キャンセル
+            </Button>
+            <Button
+              onClick={() => resetMutation.mutate(newPassword)}
+              disabled={resetMutation.isPending || newPassword.length < 8}
+            >
+              {resetMutation.isPending ? 'リセット中...' : 'リセットする'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </form>
   );
 }

--- a/frontend/src/pages/admin/members/MemberListPage.tsx
+++ b/frontend/src/pages/admin/members/MemberListPage.tsx
@@ -1,8 +1,228 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useAuth } from '@/hooks/useAuth';
+import { deleteMember, fetchMembers } from '@/lib/api/users';
+import { getApiErrorMessage } from '@/lib/api/errors';
+import type { MemberListItem, Role } from '@/types';
+
+const ROLE_LABELS: Record<Role, string> = {
+  ADMIN: '管理者',
+  STAFF: 'スタッフ',
+  INSTRUCTOR: '講師',
+};
+
+const ROLE_ALL = 'ALL';
+
 export function MemberListPage() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+
+  const [keywordInput, setKeywordInput] = useState('');
+  const [roleInput, setRoleInput] = useState<Role | typeof ROLE_ALL>(ROLE_ALL);
+  const [filters, setFilters] = useState<{ keyword: string; role: Role | '' }>({
+    keyword: '',
+    role: '',
+  });
+  const [actionError, setActionError] = useState('');
+  const [memberToDelete, setMemberToDelete] = useState<MemberListItem | null>(null);
+
+  const membersQuery = useQuery({
+    queryKey: ['members', filters],
+    queryFn: () => fetchMembers(filters),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteMember,
+    onSuccess: async () => {
+      setActionError('');
+      setMemberToDelete(null);
+      await queryClient.invalidateQueries({ queryKey: ['members'] });
+    },
+    onError: (error) => {
+      setActionError(getApiErrorMessage(error, '運営メンバーの削除に失敗しました'));
+    },
+  });
+
+  const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFilters({
+      keyword: keywordInput.trim(),
+      role: roleInput === ROLE_ALL ? '' : roleInput,
+    });
+  };
+
+  const handleDelete = () => {
+    if (!memberToDelete) return;
+    deleteMutation.mutate(memberToDelete.id);
+  };
+
   return (
     <div className="space-y-6">
-      <h2 className="text-3xl font-bold tracking-tight">運営メンバー一覧</h2>
-      <p className="text-muted-foreground">（未実装）運営メンバーの一覧表示機能を実装予定</p>
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight">運営メンバー一覧</h2>
+          <p className="text-muted-foreground">
+            管理者・スタッフ・講師の登録、編集、削除を行えます。
+          </p>
+        </div>
+        <Button asChild>
+          <Link to="/members/new">運営メンバーを登録</Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>検索条件</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="grid gap-3 md:grid-cols-[1fr_200px_auto]"
+            onSubmit={handleSearch}
+          >
+            <Input
+              value={keywordInput}
+              onChange={(event) => setKeywordInput(event.target.value)}
+              placeholder="ユーザー名・メール・氏名で検索"
+            />
+            <Select
+              value={roleInput}
+              onValueChange={(value) => setRoleInput(value as Role | typeof ROLE_ALL)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="ロール" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ROLE_ALL}>すべてのロール</SelectItem>
+                <SelectItem value="ADMIN">管理者</SelectItem>
+                <SelectItem value="STAFF">スタッフ</SelectItem>
+                <SelectItem value="INSTRUCTOR">講師</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button type="submit" disabled={membersQuery.isFetching}>
+              検索
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>運営メンバー一覧</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {actionError && (
+            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              {actionError}
+            </div>
+          )}
+
+          {membersQuery.isLoading ? (
+            <p className="text-muted-foreground">読み込み中...</p>
+          ) : membersQuery.isError ? (
+            <p className="text-sm text-destructive">
+              {getApiErrorMessage(membersQuery.error, '運営メンバー一覧の取得に失敗しました')}
+            </p>
+          ) : membersQuery.data && membersQuery.data.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ユーザー名</TableHead>
+                  <TableHead>氏名</TableHead>
+                  <TableHead>メールアドレス</TableHead>
+                  <TableHead>ロール</TableHead>
+                  <TableHead className="w-[180px]">操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {membersQuery.data.map((member) => {
+                  const isSelf = user?.id === member.id;
+                  return (
+                    <TableRow key={member.id}>
+                      <TableCell className="font-medium">{member.username}</TableCell>
+                      <TableCell>{member.name}</TableCell>
+                      <TableCell>{member.email}</TableCell>
+                      <TableCell>{ROLE_LABELS[member.role]}</TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2 whitespace-nowrap">
+                          <Button variant="outline" size="sm" asChild>
+                            <Link to={`/members/${member.id}/edit`}>編集</Link>
+                          </Button>
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => setMemberToDelete(member)}
+                            disabled={deleteMutation.isPending || isSelf}
+                            title={isSelf ? '自分自身は削除できません' : undefined}
+                          >
+                            削除
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          ) : (
+            <p className="text-muted-foreground">条件に一致する運営メンバーはいません。</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog
+        open={!!memberToDelete}
+        onOpenChange={(open) => !open && setMemberToDelete(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>運営メンバーを削除しますか？</DialogTitle>
+            <DialogDescription>
+              {memberToDelete
+                ? `「${memberToDelete.name}（${memberToDelete.username}）」を削除します。論理削除のため過去データは残りますが、ログインはできなくなります。`
+                : ''}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setMemberToDelete(null)}>
+              キャンセル
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? '削除中...' : '削除する'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -251,3 +251,41 @@ export interface HearingAnswerRow {
   answer: string;
   answeredAt: string;
 }
+
+/** 運営メンバー一覧項目 */
+export interface MemberListItem {
+  id: number;
+  username: string;
+  email: string;
+  name: string;
+  role: Role;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 運営メンバー詳細 */
+export interface MemberDetail {
+  id: number;
+  username: string;
+  email: string;
+  name: string;
+  role: Role;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 運営メンバー登録入力 */
+export interface MemberCreateInput {
+  username: string;
+  email: string;
+  name: string;
+  role: Role;
+  password: string;
+}
+
+/** 運営メンバー更新入力 */
+export interface MemberUpdateInput {
+  email: string;
+  name: string;
+  role: Role;
+}


### PR DESCRIPTION
## Summary

Phase 7「運営機能強化」のサブフェーズA。運営メンバー（ADMIN/STAFF/INSTRUCTOR）の CRUD と本人パスワード変更、管理者によるパスワードリセットを実装する。Closes #30

## バックエンド変更

- `V7__users_soft_delete.sql`: `users.deleted_at` を追加し論理削除を導入
- `UserMapper`: `findAll`/`countActiveAdmins`/`insert`/`update`/`updatePassword`/`softDelete`/`existsByEmail*` を追加。既存 SELECT は `deleted_at IS NULL` を条件に追加
- `UserController` (`/api/users`, ADMIN 限定)
  - `GET` 検索（keyword, role）
  - `GET /{id}`
  - `POST` 登録（パスワードハッシュ化）
  - `PUT /{id}` 氏名・メール・ロール
  - `POST /{id}/password-reset` 管理者リセット
  - `DELETE /{id}` 論理削除（自分自身/最後の ADMIN は 409）
- `AuthController#POST /api/auth/password`: 本人パスワード変更（現パスワード検証 + 同一拒否）
- バリデーション
  - パスワード 8〜128 文字、英字＋数字必須
  - ロールは ADMIN/STAFF/INSTRUCTOR
  - username/email は重複時 409
- `UserManagementServiceTest`: CRUD/自己削除拒否/最後の ADMIN 拒否/重複/リセットを網羅

## フロントエンド変更

- `lib/api/users.ts`: `fetchMembers`/`fetchMember`/`createMember`/`updateMember`/`deleteMember`/`resetMemberPassword`/`changeMyPassword`
- `MemberListPage`: 検索 + ロールフィルタ + テーブル + 自分自身の削除無効化 + 削除確認ダイアログ
- `MemberEditPage`: 新規/編集兼用、ユーザー名は新規時のみ編集可、初期パスワード必須、編集時はパスワードリセット用ダイアログ。自分自身編集中はロール変更不可
- `PasswordChangePage`: 現/新/確認の 3 フィールド、確認一致チェック
- `types/index.ts`: `MemberListItem` / `MemberDetail` / `MemberCreateInput` / `MemberUpdateInput` を追加

## Test plan

- [x] backend: `./gradlew test` パス（`UserManagementServiceTest` 含む）
- [x] frontend: `npx tsc -b --noEmit` / `npm run lint` パス
- [ ] ローカル PostgreSQL で V7 マイグレーションを適用してログイン・削除済みユーザーがログイン不可になることを確認
- [ ] /members で運営メンバー一覧→新規→編集→削除→パスワードリセット→/password でログインユーザーのパスワード変更を一通り操作

## 注意

- 既存 `db/local/V1001__seed_local_users.sql` は変更なし。`V7` で `deleted_at` カラムが追加されるが NULL 許容のため既存ユーザーは引き続き有効。
