### PR TITLE
feat: Phase7-C 集計ダッシュボード実装 (#34)

### DIFF
--- a/backend/src/main/java/com/student/management/controller/AnalyticsController.java
+++ b/backend/src/main/java/com/student/management/controller/AnalyticsController.java
@@ -1,0 +1,64 @@
+package com.student.management.controller;
+
+import com.student.management.dto.analytics.AnalyticsOverviewResponse;
+import com.student.management.dto.analytics.CourseStatItem;
+import com.student.management.dto.analytics.MonthlyStatItem;
+import com.student.management.dto.analytics.PaymentSummary;
+import com.student.management.dto.analytics.ReferralSourceStatItem;
+import com.student.management.service.AnalyticsService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/analytics")
+@PreAuthorize("hasAnyRole('ADMIN', 'STAFF')")
+public class AnalyticsController {
+
+    private final AnalyticsService analyticsService;
+
+    public AnalyticsController(AnalyticsService analyticsService) {
+        this.analyticsService = analyticsService;
+    }
+
+    @GetMapping("/overview")
+    public ResponseEntity<AnalyticsOverviewResponse> overview(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return ResponseEntity.ok(analyticsService.getOverview(from, to));
+    }
+
+    @GetMapping("/referral-sources")
+    public ResponseEntity<List<ReferralSourceStatItem>> referralSources(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return ResponseEntity.ok(analyticsService.getReferralSourceStats(from, to));
+    }
+
+    @GetMapping("/courses")
+    public ResponseEntity<List<CourseStatItem>> courses(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return ResponseEntity.ok(analyticsService.getCourseStats(from, to));
+    }
+
+    @GetMapping("/monthly")
+    public ResponseEntity<List<MonthlyStatItem>> monthly(
+            @RequestParam(required = false) Integer months) {
+        return ResponseEntity.ok(analyticsService.getMonthlyStats(months));
+    }
+
+    @GetMapping("/payments/summary")
+    public ResponseEntity<PaymentSummary> paymentsSummary(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return ResponseEntity.ok(analyticsService.getPaymentSummary(from, to));
+    }
+}

--- a/backend/src/main/java/com/student/management/dto/analytics/AnalyticsOverviewResponse.java
+++ b/backend/src/main/java/com/student/management/dto/analytics/AnalyticsOverviewResponse.java
@@ -1,0 +1,8 @@
+package com.student.management.dto.analytics;
+
+public record AnalyticsOverviewResponse(
+        long newStudents,
+        long activeEnrollments,
+        PaymentSummary payments
+) {
+}

--- a/backend/src/main/java/com/student/management/dto/analytics/CourseStatItem.java
+++ b/backend/src/main/java/com/student/management/dto/analytics/CourseStatItem.java
@@ -1,0 +1,10 @@
+package com.student.management.dto.analytics;
+
+public record CourseStatItem(
+        Long id,
+        String name,
+        long enrollmentCount,
+        long revenuePaid,
+        long revenueUnpaid
+) {
+}

--- a/backend/src/main/java/com/student/management/dto/analytics/MonthlyStatItem.java
+++ b/backend/src/main/java/com/student/management/dto/analytics/MonthlyStatItem.java
@@ -1,0 +1,9 @@
+package com.student.management.dto.analytics;
+
+public record MonthlyStatItem(
+        String month,
+        long newStudents,
+        long paidAmount,
+        long unpaidAmount
+) {
+}

--- a/backend/src/main/java/com/student/management/dto/analytics/PaymentSummary.java
+++ b/backend/src/main/java/com/student/management/dto/analytics/PaymentSummary.java
@@ -1,0 +1,9 @@
+package com.student.management.dto.analytics;
+
+public record PaymentSummary(
+        long totalPaid,
+        long totalUnpaid,
+        long countPaid,
+        long countUnpaid
+) {
+}

--- a/backend/src/main/java/com/student/management/dto/analytics/ReferralSourceStatItem.java
+++ b/backend/src/main/java/com/student/management/dto/analytics/ReferralSourceStatItem.java
@@ -1,0 +1,9 @@
+package com.student.management.dto.analytics;
+
+public record ReferralSourceStatItem(
+        Long id,
+        String name,
+        String category,
+        long studentCount
+) {
+}

--- a/backend/src/main/java/com/student/management/repository/AnalyticsMapper.java
+++ b/backend/src/main/java/com/student/management/repository/AnalyticsMapper.java
@@ -1,0 +1,31 @@
+package com.student.management.repository;
+
+import com.student.management.dto.analytics.CourseStatItem;
+import com.student.management.dto.analytics.MonthlyStatItem;
+import com.student.management.dto.analytics.PaymentSummary;
+import com.student.management.dto.analytics.ReferralSourceStatItem;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Mapper
+public interface AnalyticsMapper {
+
+    List<ReferralSourceStatItem> aggregateByReferralSource(@Param("from") LocalDate from,
+                                                           @Param("to") LocalDate to);
+
+    List<CourseStatItem> aggregateByCourse(@Param("from") LocalDate from,
+                                           @Param("to") LocalDate to);
+
+    List<MonthlyStatItem> aggregateMonthly(@Param("months") int months);
+
+    PaymentSummary summarizePayments(@Param("from") LocalDate from,
+                                     @Param("to") LocalDate to);
+
+    long countNewStudents(@Param("from") LocalDate from,
+                          @Param("to") LocalDate to);
+
+    long countActiveEnrollments();
+}

--- a/backend/src/main/java/com/student/management/service/AnalyticsService.java
+++ b/backend/src/main/java/com/student/management/service/AnalyticsService.java
@@ -1,0 +1,63 @@
+package com.student.management.service;
+
+import com.student.management.dto.analytics.AnalyticsOverviewResponse;
+import com.student.management.dto.analytics.CourseStatItem;
+import com.student.management.dto.analytics.MonthlyStatItem;
+import com.student.management.dto.analytics.PaymentSummary;
+import com.student.management.dto.analytics.ReferralSourceStatItem;
+import com.student.management.exception.ApiException;
+import com.student.management.repository.AnalyticsMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class AnalyticsService {
+
+    private static final int DEFAULT_MONTHS = 12;
+    private static final int MAX_MONTHS = 36;
+
+    private final AnalyticsMapper analyticsMapper;
+
+    public AnalyticsService(AnalyticsMapper analyticsMapper) {
+        this.analyticsMapper = analyticsMapper;
+    }
+
+    public List<ReferralSourceStatItem> getReferralSourceStats(LocalDate from, LocalDate to) {
+        validateRange(from, to);
+        return analyticsMapper.aggregateByReferralSource(from, to);
+    }
+
+    public List<CourseStatItem> getCourseStats(LocalDate from, LocalDate to) {
+        validateRange(from, to);
+        return analyticsMapper.aggregateByCourse(from, to);
+    }
+
+    public List<MonthlyStatItem> getMonthlyStats(Integer months) {
+        int m = (months == null || months <= 0) ? DEFAULT_MONTHS : Math.min(months, MAX_MONTHS);
+        return analyticsMapper.aggregateMonthly(m);
+    }
+
+    public PaymentSummary getPaymentSummary(LocalDate from, LocalDate to) {
+        validateRange(from, to);
+        return analyticsMapper.summarizePayments(from, to);
+    }
+
+    public AnalyticsOverviewResponse getOverview(LocalDate from, LocalDate to) {
+        validateRange(from, to);
+        long newStudents = analyticsMapper.countNewStudents(from, to);
+        long activeEnrollments = analyticsMapper.countActiveEnrollments();
+        PaymentSummary payments = analyticsMapper.summarizePayments(from, to);
+        return new AnalyticsOverviewResponse(newStudents, activeEnrollments, payments);
+    }
+
+    private void validateRange(LocalDate from, LocalDate to) {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "from は to 以前の日付を指定してください");
+        }
+    }
+}

--- a/backend/src/main/resources/mapper/AnalyticsMapper.xml
+++ b/backend/src/main/resources/mapper/AnalyticsMapper.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.student.management.repository.AnalyticsMapper">
+
+    <select id="aggregateByReferralSource" resultType="com.student.management.dto.analytics.ReferralSourceStatItem">
+        SELECT
+            rs.id            AS id,
+            rs.name          AS name,
+            rs.category      AS category,
+            COUNT(s.id)      AS studentCount
+        FROM referral_sources rs
+        LEFT JOIN students s
+               ON s.referral_source_id = rs.id
+                  <if test="from != null">
+                      AND s.created_at &gt;= #{from}
+                  </if>
+                  <if test="to != null">
+                      AND s.created_at &lt; (CAST(#{to} AS DATE) + INTERVAL '1 day')
+                  </if>
+        WHERE rs.deleted_at IS NULL
+        GROUP BY rs.id, rs.name, rs.category, rs.display_order
+        ORDER BY rs.display_order ASC, rs.id ASC
+    </select>
+
+    <select id="aggregateByCourse" resultType="com.student.management.dto.analytics.CourseStatItem">
+        SELECT
+            c.id   AS id,
+            c.name AS name,
+            COUNT(DISTINCT e.id) AS enrollmentCount,
+            COALESCE(SUM(CASE WHEN p.status = 'PAID'   THEN p.amount ELSE 0 END), 0) AS revenuePaid,
+            COALESCE(SUM(CASE WHEN p.status = 'UNPAID' THEN p.amount ELSE 0 END), 0) AS revenueUnpaid
+        FROM courses c
+        LEFT JOIN enrollments e
+               ON e.course_id = c.id
+                  <if test="from != null">
+                      AND e.created_at &gt;= #{from}
+                  </if>
+                  <if test="to != null">
+                      AND e.created_at &lt; (CAST(#{to} AS DATE) + INTERVAL '1 day')
+                  </if>
+        LEFT JOIN payments p
+               ON p.enrollment_id = e.id
+        GROUP BY c.id, c.name
+        ORDER BY enrollmentCount DESC, c.id ASC
+    </select>
+
+    <select id="aggregateMonthly" resultType="com.student.management.dto.analytics.MonthlyStatItem">
+        WITH months AS (
+            SELECT generate_series(
+                date_trunc('month', CURRENT_DATE) - INTERVAL '1 month' * (#{months} - 1),
+                date_trunc('month', CURRENT_DATE),
+                INTERVAL '1 month'
+            )::date AS month_start
+        )
+        SELECT
+            to_char(m.month_start, 'YYYY-MM') AS month,
+            COALESCE(s.cnt, 0)  AS newStudents,
+            COALESCE(p.paid, 0) AS paidAmount,
+            COALESCE(p.unpaid, 0) AS unpaidAmount
+        FROM months m
+        LEFT JOIN (
+            SELECT date_trunc('month', created_at)::date AS month_start, COUNT(*) AS cnt
+            FROM students
+            GROUP BY date_trunc('month', created_at)
+        ) s ON s.month_start = m.month_start
+        LEFT JOIN (
+            SELECT
+                date_trunc('month', COALESCE(paid_date, due_date))::date AS month_start,
+                SUM(CASE WHEN status = 'PAID'   THEN amount ELSE 0 END) AS paid,
+                SUM(CASE WHEN status = 'UNPAID' THEN amount ELSE 0 END) AS unpaid
+            FROM payments
+            GROUP BY date_trunc('month', COALESCE(paid_date, due_date))
+        ) p ON p.month_start = m.month_start
+        ORDER BY m.month_start ASC
+    </select>
+
+    <select id="summarizePayments" resultType="com.student.management.dto.analytics.PaymentSummary">
+        SELECT
+            COALESCE(SUM(CASE WHEN status = 'PAID'   THEN amount ELSE 0 END), 0) AS totalPaid,
+            COALESCE(SUM(CASE WHEN status = 'UNPAID' THEN amount ELSE 0 END), 0) AS totalUnpaid,
+            COALESCE(SUM(CASE WHEN status = 'PAID'   THEN 1 ELSE 0 END), 0)      AS countPaid,
+            COALESCE(SUM(CASE WHEN status = 'UNPAID' THEN 1 ELSE 0 END), 0)      AS countUnpaid
+        FROM payments
+        <where>
+            <if test="from != null">
+                AND COALESCE(paid_date, due_date) &gt;= #{from}
+            </if>
+            <if test="to != null">
+                AND COALESCE(paid_date, due_date) &lt;= #{to}
+            </if>
+        </where>
+    </select>
+
+    <select id="countNewStudents" resultType="long">
+        SELECT COUNT(*)
+        FROM students
+        <where>
+            <if test="from != null">
+                AND created_at &gt;= #{from}
+            </if>
+            <if test="to != null">
+                AND created_at &lt; (CAST(#{to} AS DATE) + INTERVAL '1 day')
+            </if>
+        </where>
+    </select>
+
+    <select id="countActiveEnrollments" resultType="long">
+        SELECT COUNT(*) FROM enrollments WHERE status = 'ENROLLED'
+    </select>
+
+</mapper>

--- a/backend/src/test/java/com/student/management/service/AnalyticsServiceTest.java
+++ b/backend/src/test/java/com/student/management/service/AnalyticsServiceTest.java
@@ -1,0 +1,78 @@
+package com.student.management.service;
+
+import com.student.management.dto.analytics.PaymentSummary;
+import com.student.management.exception.ApiException;
+import com.student.management.repository.AnalyticsMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsServiceTest {
+
+    @Mock
+    private AnalyticsMapper analyticsMapper;
+
+    @InjectMocks
+    private AnalyticsService analyticsService;
+
+    @Test
+    void getOverview_returnsAggregates() {
+        LocalDate from = LocalDate.of(2026, 1, 1);
+        LocalDate to = LocalDate.of(2026, 4, 30);
+        when(analyticsMapper.countNewStudents(from, to)).thenReturn(15L);
+        when(analyticsMapper.countActiveEnrollments()).thenReturn(42L);
+        when(analyticsMapper.summarizePayments(from, to))
+                .thenReturn(new PaymentSummary(100_000L, 30_000L, 5L, 2L));
+
+        var overview = analyticsService.getOverview(from, to);
+
+        assertThat(overview.newStudents()).isEqualTo(15L);
+        assertThat(overview.activeEnrollments()).isEqualTo(42L);
+        assertThat(overview.payments().totalPaid()).isEqualTo(100_000L);
+    }
+
+    @Test
+    void getOverview_whenFromAfterTo_throwsBadRequest() {
+        LocalDate from = LocalDate.of(2026, 4, 1);
+        LocalDate to = LocalDate.of(2026, 1, 1);
+
+        assertThatThrownBy(() -> analyticsService.getOverview(from, to))
+                .isInstanceOf(ApiException.class)
+                .extracting(ex -> ((ApiException) ex).getStatus())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+
+        verify(analyticsMapper, never()).countNewStudents(any(), any());
+    }
+
+    @Test
+    void getMonthlyStats_clampsToMaximum() {
+        when(analyticsMapper.aggregateMonthly(36)).thenReturn(java.util.List.of());
+
+        analyticsService.getMonthlyStats(999);
+
+        verify(analyticsMapper).aggregateMonthly(36);
+    }
+
+    @Test
+    void getMonthlyStats_defaultsTo12_whenNullOrZero() {
+        when(analyticsMapper.aggregateMonthly(12)).thenReturn(java.util.List.of());
+
+        analyticsService.getMonthlyStats(null);
+        analyticsService.getMonthlyStats(0);
+
+        verify(analyticsMapper, org.mockito.Mockito.times(2)).aggregateMonthly(12);
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.71.1",
         "react-router": "^7.13.0",
+        "recharts": "^3.8.1",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.18",
         "zod": "^4.3.6"
@@ -3259,6 +3260,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
@@ -3610,6 +3647,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
@@ -4002,6 +4045,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4050,6 +4156,12 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -5102,6 +5214,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -5129,6 +5362,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.1",
@@ -5402,6 +5641,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -5697,6 +5946,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -6508,6 +6763,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6541,6 +6806,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.0.1",
@@ -8275,6 +8549,36 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -8393,6 +8697,51 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8412,6 +8761,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -9049,7 +9404,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -9466,6 +9820,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.1",
     "react-router": "^7.13.0",
+    "recharts": "^3.8.1",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
     "zod": "^4.3.6"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { MemberListPage } from '@/pages/admin/members/MemberListPage';
 import { MemberEditPage } from '@/pages/admin/members/MemberEditPage';
 import { ReferralSourceListPage } from '@/pages/admin/referral-sources/ReferralSourceListPage';
 import { ReferralSourceEditPage } from '@/pages/admin/referral-sources/ReferralSourceEditPage';
+import { AnalyticsPage } from '@/pages/admin/analytics/AnalyticsPage';
 import { PasswordChangePage } from '@/pages/admin/PasswordChangePage';
 import { EnrollmentListPage } from '@/pages/admin/enrollments/EnrollmentListPage';
 import { PaymentListPage } from '@/pages/admin/payments/PaymentListPage';
@@ -87,6 +88,11 @@ export default function App() {
                     path="/referral-sources/:id/edit"
                     element={<ReferralSourceEditPage />}
                   />
+                </Route>
+
+                {/* 集計・分析 */}
+                <Route element={<AuthGuard allowedRoles={['ADMIN', 'STAFF']} />}>
+                  <Route path="/analytics" element={<AnalyticsPage />} />
                 </Route>
 
                 {/* メールテンプレート管理（管理者のみ） */}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -18,6 +18,7 @@ const navItems: NavItem[] = [
   { label: '決済', to: '/payments' },
   { label: 'コース管理', to: '/courses' },
   { label: '申込経路マスタ', to: '/referral-sources', roles: ['ADMIN', 'STAFF'] },
+  { label: '集計・分析', to: '/analytics', roles: ['ADMIN', 'STAFF'] },
   { label: 'メールテンプレート', to: '/mail-templates', roles: ['ADMIN'] },
   { label: '運営メンバー', to: '/members', roles: ['ADMIN'] },
 ];

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -42,6 +42,7 @@ export const ROUTES = {
   PASSWORD_CHANGE: '/password',
   ENROLLMENTS: '/enrollments',
   PAYMENTS: '/payments',
+  ANALYTICS: '/analytics',
 } as const;
 
 /** 受講生の状態ラベル */

--- a/frontend/src/lib/api/analytics.ts
+++ b/frontend/src/lib/api/analytics.ts
@@ -1,0 +1,56 @@
+import apiClient from '@/lib/api/client';
+import type {
+  AnalyticsOverview,
+  CourseStatItem,
+  MonthlyStatItem,
+  PaymentSummary,
+  ReferralSourceStatItem,
+} from '@/types';
+
+export interface DateRangeParams {
+  from?: string;
+  to?: string;
+}
+
+function buildParams(params: DateRangeParams) {
+  const search: Record<string, string> = {};
+  if (params.from) search.from = params.from;
+  if (params.to) search.to = params.to;
+  return search;
+}
+
+export async function fetchAnalyticsOverview(params: DateRangeParams = {}) {
+  const response = await apiClient.get<AnalyticsOverview>('/analytics/overview', {
+    params: buildParams(params),
+  });
+  return response.data;
+}
+
+export async function fetchAnalyticsReferralSources(params: DateRangeParams = {}) {
+  const response = await apiClient.get<ReferralSourceStatItem[]>(
+    '/analytics/referral-sources',
+    { params: buildParams(params) },
+  );
+  return response.data;
+}
+
+export async function fetchAnalyticsCourses(params: DateRangeParams = {}) {
+  const response = await apiClient.get<CourseStatItem[]>('/analytics/courses', {
+    params: buildParams(params),
+  });
+  return response.data;
+}
+
+export async function fetchAnalyticsMonthly(months = 12) {
+  const response = await apiClient.get<MonthlyStatItem[]>('/analytics/monthly', {
+    params: { months },
+  });
+  return response.data;
+}
+
+export async function fetchAnalyticsPaymentSummary(params: DateRangeParams = {}) {
+  const response = await apiClient.get<PaymentSummary>('/analytics/payments/summary', {
+    params: buildParams(params),
+  });
+  return response.data;
+}

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -39,7 +39,15 @@ export function DashboardPage() {
 
   return (
     <div className="space-y-6">
-      <h2 className="text-3xl font-bold tracking-tight">ダッシュボード</h2>
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <h2 className="text-3xl font-bold tracking-tight">ダッシュボード</h2>
+        <Link
+          to={ROUTES.ANALYTICS}
+          className="text-sm font-medium text-primary hover:underline"
+        >
+          集計・分析を見る →
+        </Link>
+      </div>
       {isError && (
         <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
           統計データの取得に失敗しました。

--- a/frontend/src/pages/admin/analytics/AnalyticsPage.tsx
+++ b/frontend/src/pages/admin/analytics/AnalyticsPage.tsx
@@ -1,0 +1,463 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  fetchAnalyticsCourses,
+  fetchAnalyticsMonthly,
+  fetchAnalyticsOverview,
+  fetchAnalyticsReferralSources,
+} from '@/lib/api/analytics';
+import { getApiErrorMessage } from '@/lib/api/errors';
+import type { ReferralSourceCategory } from '@/types';
+
+type Preset = 'thisMonth' | 'last3' | 'last12' | 'custom';
+
+const CATEGORY_COLORS: Record<ReferralSourceCategory, string> = {
+  WEB: '#3b82f6',
+  AD: '#f97316',
+  SEARCH: '#10b981',
+  AI: '#a855f7',
+  SNS: '#ec4899',
+  REFERRAL: '#eab308',
+  OTHER: '#94a3b8',
+};
+
+const DEFAULT_COLOR = '#64748b';
+
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function presetRange(preset: Preset): { from: string; to: string } {
+  const today = new Date();
+  const to = formatDate(today);
+  if (preset === 'thisMonth') {
+    const first = new Date(today.getFullYear(), today.getMonth(), 1);
+    return { from: formatDate(first), to };
+  }
+  if (preset === 'last3') {
+    const start = new Date(today);
+    start.setMonth(start.getMonth() - 2);
+    start.setDate(1);
+    return { from: formatDate(start), to };
+  }
+  // last12
+  const start = new Date(today);
+  start.setMonth(start.getMonth() - 11);
+  start.setDate(1);
+  return { from: formatDate(start), to };
+}
+
+function formatYen(value: number): string {
+  return `¥${value.toLocaleString('ja-JP')}`;
+}
+
+export function AnalyticsPage() {
+  const [preset, setPreset] = useState<Preset>('last12');
+  const [customRange, setCustomRange] = useState<{ from: string; to: string }>(() =>
+    presetRange('last12'),
+  );
+
+  const range = useMemo(() => {
+    if (preset === 'custom') return customRange;
+    return presetRange(preset);
+  }, [preset, customRange]);
+
+  const overviewQuery = useQuery({
+    queryKey: ['analytics', 'overview', range],
+    queryFn: () => fetchAnalyticsOverview(range),
+  });
+  const referralQuery = useQuery({
+    queryKey: ['analytics', 'referral-sources', range],
+    queryFn: () => fetchAnalyticsReferralSources(range),
+  });
+  const courseQuery = useQuery({
+    queryKey: ['analytics', 'courses', range],
+    queryFn: () => fetchAnalyticsCourses(range),
+  });
+  const monthlyQuery = useQuery({
+    queryKey: ['analytics', 'monthly', 12],
+    queryFn: () => fetchAnalyticsMonthly(12),
+  });
+
+  const overview = overviewQuery.data;
+  const referralData = referralQuery.data ?? [];
+  const courseData = courseQuery.data ?? [];
+  const monthlyData = monthlyQuery.data ?? [];
+
+  const referralChartData = referralData.map((item) => ({
+    name: item.name,
+    value: item.studentCount,
+    category: item.category,
+  }));
+
+  const courseChartData = courseData.map((item) => ({
+    name: item.name,
+    enrollments: item.enrollmentCount,
+    paid: item.revenuePaid,
+    unpaid: item.revenueUnpaid,
+  }));
+
+  const kpiCards = [
+    {
+      title: '新規受講生',
+      value: overview ? overview.newStudents.toLocaleString('ja-JP') : '-',
+      description: '指定期間に登録された受講生数',
+    },
+    {
+      title: '受講中',
+      value: overview ? overview.activeEnrollments.toLocaleString('ja-JP') : '-',
+      description: '現在受講中の件数 (期間に依存しない)',
+    },
+    {
+      title: '入金額',
+      value: overview ? formatYen(overview.payments.totalPaid) : '-',
+      description: `入金件数 ${overview?.payments.countPaid ?? 0} 件`,
+    },
+    {
+      title: '未収金額',
+      value: overview ? formatYen(overview.payments.totalUnpaid) : '-',
+      description: `未収件数 ${overview?.payments.countUnpaid ?? 0} 件`,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight">集計・分析</h2>
+        <p className="text-muted-foreground">
+          指定した期間の受講生獲得状況、コース別売上、月次推移を確認できます。
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>期間</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant={preset === 'thisMonth' ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setPreset('thisMonth')}
+            >
+              今月
+            </Button>
+            <Button
+              variant={preset === 'last3' ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setPreset('last3')}
+            >
+              直近3ヶ月
+            </Button>
+            <Button
+              variant={preset === 'last12' ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setPreset('last12')}
+            >
+              直近12ヶ月
+            </Button>
+            <Button
+              variant={preset === 'custom' ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setPreset('custom')}
+            >
+              カスタム
+            </Button>
+          </div>
+
+          {preset === 'custom' && (
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="from">開始日</Label>
+                <Input
+                  id="from"
+                  type="date"
+                  value={customRange.from}
+                  onChange={(e) =>
+                    setCustomRange((prev) => ({ ...prev, from: e.target.value }))
+                  }
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="to">終了日</Label>
+                <Input
+                  id="to"
+                  type="date"
+                  value={customRange.to}
+                  onChange={(e) =>
+                    setCustomRange((prev) => ({ ...prev, to: e.target.value }))
+                  }
+                />
+              </div>
+            </div>
+          )}
+
+          <p className="text-sm text-muted-foreground">
+            集計期間: {range.from} 〜 {range.to}
+          </p>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {kpiCards.map((card) => (
+          <Card key={card.title}>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">{card.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">
+                {overviewQuery.isLoading ? '...' : card.value}
+              </div>
+              <p className="text-xs text-muted-foreground">{card.description}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>申込経路別 受講生数</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {referralQuery.isLoading ? (
+            <p className="text-muted-foreground">読み込み中...</p>
+          ) : referralQuery.isError ? (
+            <p className="text-sm text-destructive">
+              {getApiErrorMessage(referralQuery.error, '集計の取得に失敗しました')}
+            </p>
+          ) : referralChartData.length === 0 ? (
+            <p className="text-muted-foreground">データがありません。</p>
+          ) : (
+            <div className="h-80 w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={referralChartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                  <YAxis allowDecimals={false} />
+                  <Tooltip
+                    formatter={(value) => [`${Number(value)} 名`, '受講生']}
+                    labelFormatter={(label) => `経路: ${label}`}
+                  />
+                  <Legend />
+                  <Bar dataKey="value" name="受講生数">
+                    {referralChartData.map((entry, index) => (
+                      <Cell
+                        key={`cell-${index}`}
+                        fill={
+                          CATEGORY_COLORS[entry.category as ReferralSourceCategory] ??
+                          DEFAULT_COLOR
+                        }
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>コース別 受講生数・売上</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {courseQuery.isLoading ? (
+            <p className="text-muted-foreground">読み込み中...</p>
+          ) : courseQuery.isError ? (
+            <p className="text-sm text-destructive">
+              {getApiErrorMessage(courseQuery.error, '集計の取得に失敗しました')}
+            </p>
+          ) : courseChartData.length === 0 ? (
+            <p className="text-muted-foreground">データがありません。</p>
+          ) : (
+            <div className="h-96 w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={courseChartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                  <YAxis
+                    yAxisId="left"
+                    allowDecimals={false}
+                    label={{ value: '受講生数', angle: -90, position: 'insideLeft' }}
+                  />
+                  <YAxis
+                    yAxisId="right"
+                    orientation="right"
+                    tickFormatter={(value: number) => `¥${(value / 1000).toFixed(0)}k`}
+                  />
+                  <Tooltip
+                    formatter={(value, name) => {
+                      const numericValue = Number(value);
+                      if (name === '受講生数') return [`${numericValue} 名`, name];
+                      return [formatYen(numericValue), name];
+                    }}
+                  />
+                  <Legend />
+                  <Bar
+                    yAxisId="left"
+                    dataKey="enrollments"
+                    name="受講生数"
+                    fill="#3b82f6"
+                  />
+                  <Bar
+                    yAxisId="right"
+                    dataKey="paid"
+                    name="入金済み"
+                    fill="#10b981"
+                  />
+                  <Bar
+                    yAxisId="right"
+                    dataKey="unpaid"
+                    name="未収"
+                    fill="#ef4444"
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>月次推移 (直近12ヶ月)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {monthlyQuery.isLoading ? (
+            <p className="text-muted-foreground">読み込み中...</p>
+          ) : monthlyQuery.isError ? (
+            <p className="text-sm text-destructive">
+              {getApiErrorMessage(monthlyQuery.error, '月次推移の取得に失敗しました')}
+            </p>
+          ) : monthlyData.length === 0 ? (
+            <p className="text-muted-foreground">データがありません。</p>
+          ) : (
+            <div className="h-80 w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={monthlyData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="month" />
+                  <YAxis
+                    yAxisId="left"
+                    allowDecimals={false}
+                    label={{ value: '新規受講生', angle: -90, position: 'insideLeft' }}
+                  />
+                  <YAxis
+                    yAxisId="right"
+                    orientation="right"
+                    tickFormatter={(value: number) => `¥${(value / 1000).toFixed(0)}k`}
+                  />
+                  <Tooltip
+                    formatter={(value, name) => {
+                      const numericValue = Number(value);
+                      if (name === '新規受講生') return [`${numericValue} 名`, name];
+                      return [formatYen(numericValue), name];
+                    }}
+                  />
+                  <Legend />
+                  <Line
+                    yAxisId="left"
+                    type="monotone"
+                    dataKey="newStudents"
+                    name="新規受講生"
+                    stroke="#3b82f6"
+                    strokeWidth={2}
+                  />
+                  <Line
+                    yAxisId="right"
+                    type="monotone"
+                    dataKey="paidAmount"
+                    name="入金額"
+                    stroke="#10b981"
+                    strokeWidth={2}
+                  />
+                  <Line
+                    yAxisId="right"
+                    type="monotone"
+                    dataKey="unpaidAmount"
+                    name="未収額"
+                    stroke="#ef4444"
+                    strokeWidth={2}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>コース別 売上明細</CardTitle>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/payments">決済管理へ</Link>
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {courseQuery.isLoading ? (
+            <p className="text-muted-foreground">読み込み中...</p>
+          ) : courseData.length === 0 ? (
+            <p className="text-muted-foreground">データがありません。</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>コース名</TableHead>
+                  <TableHead className="text-right">受講生数</TableHead>
+                  <TableHead className="text-right">入金済み</TableHead>
+                  <TableHead className="text-right">未収</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {courseData.map((course) => (
+                  <TableRow key={course.id}>
+                    <TableCell className="font-medium">{course.name}</TableCell>
+                    <TableCell className="text-right">
+                      {course.enrollmentCount.toLocaleString('ja-JP')}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatYen(course.revenuePaid)}
+                    </TableCell>
+                    <TableCell className="text-right text-destructive">
+                      {formatYen(course.revenueUnpaid)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -317,3 +317,43 @@ export interface ReferralSourceInput {
   category: ReferralSourceCategory;
   displayOrder: number;
 }
+
+/** 集計: 申込経路別 */
+export interface ReferralSourceStatItem {
+  id: number;
+  name: string;
+  category: ReferralSourceCategory | string;
+  studentCount: number;
+}
+
+/** 集計: コース別 */
+export interface CourseStatItem {
+  id: number;
+  name: string;
+  enrollmentCount: number;
+  revenuePaid: number;
+  revenueUnpaid: number;
+}
+
+/** 集計: 月次 */
+export interface MonthlyStatItem {
+  month: string;
+  newStudents: number;
+  paidAmount: number;
+  unpaidAmount: number;
+}
+
+/** 集計: 支払いサマリ */
+export interface PaymentSummary {
+  totalPaid: number;
+  totalUnpaid: number;
+  countPaid: number;
+  countUnpaid: number;
+}
+
+/** 集計: 概要 */
+export interface AnalyticsOverview {
+  newStudents: number;
+  activeEnrollments: number;
+  payments: PaymentSummary;
+}


### PR DESCRIPTION
## 概要

Phase 7-C「集計ダッシュボード」を実装します。Issue #34。

運営メンバー (ADMIN/STAFF) が、申込経路・コース・月次推移・支払状況を視覚的に把握できるダッシュボードを追加しました。

## 主な変更

### バックエンド
- `AnalyticsController` 新設 (`/api/analytics/*`、ADMIN/STAFF のみ)
  - `GET /api/analytics/overview` — KPI 用サマリ (新規受講生 / 受講中 / 入金・未収)
  - `GET /api/analytics/referral-sources` — 経路別受講生数
  - `GET /api/analytics/courses` — コース別受講生数 + 売上 (入金/未収)
  - `GET /api/analytics/monthly?months=N` — 月次推移 (新規受講生 / 入金額 / 未収額)
  - `GET /api/analytics/payments/summary` — 支払いサマリ
- `AnalyticsService` を新設し、期間バリデーション (`from <= to`) と月数の上限 (1〜36ヶ月、既定12) を実装。
- `AnalyticsMapper` (XML) で集計クエリを集約。月次は `generate_series` + `to_char(date_trunc('month', ...))` でゼロ件月を埋める。
- `AnalyticsServiceTest` を追加 (期間バリデーション・月数のクランプ・概要集計)。

### フロントエンド
- `recharts` を導入。
- `frontend/src/lib/api/analytics.ts` で API クライアントを実装。
- `frontend/src/pages/admin/analytics/AnalyticsPage.tsx` を新設。
  - 期間ピッカー (今月 / 直近3ヶ月 / 直近12ヶ月 / カスタム)
  - KPI カード (新規受講生 / 受講中 / 入金額 / 未収金額)
  - 棒グラフ: 申込経路別受講生数 (カテゴリで色分け)
  - 棒グラフ: コース別受講生数 + 入金/未収売上 (左右軸)
  - 折れ線グラフ: 月次推移 (新規受講生 + 入金額 + 未収額)
  - 表: コース別売上明細 (決済管理へのリンク付き)
- サイドバーに「集計・分析」を追加 (ADMIN/STAFF)。
- ダッシュボードから集計ページへの導線を追加。
- ルート `/analytics` を `AuthGuard(ADMIN, STAFF)` で保護。

## テスト

- `./gradlew compileJava test` — 成功
- `npx tsc -b --noEmit` — 成功
- `npm run lint` — 成功

## チェックリスト

- [x] バックエンド: コンパイル・ユニットテスト
- [x] フロント: 型チェック・ESLint
- [ ] ローカル PostgreSQL での集計クエリ動作確認 (任意)
